### PR TITLE
chore: Get correct window if node is a Document

### DIFF
--- a/sources/accessible-name.ts
+++ b/sources/accessible-name.ts
@@ -59,11 +59,13 @@ function isHTMLTextAreaElement(node: Node | null): node is HTMLTextAreaElement {
 }
 
 function safeWindow(node: Node): Window {
-	if (node.isConnected === false) {
-		throw new TypeError(`Can't reach window from disconnected node`);
-	}
+	const { defaultView } =
+		node.ownerDocument === null ? (node as Document) : node.ownerDocument;
 
-	return node.ownerDocument!.defaultView!;
+	if (defaultView === null) {
+		throw new TypeError("no window available");
+	}
+	return defaultView;
 }
 
 /**


### PR DESCRIPTION
It doesn't have anything to do with the node being connect but rather if the node is a `Document` or not.

>  If this property is used on a node that is itself a document, the value is null.

-- https://developer.mozilla.org/en-US/docs/Web/API/Node/ownerDocument