### PR TITLE
chore: Remove unused options for public method

### DIFF
--- a/sources/accessible-name.ts
+++ b/sources/accessible-name.ts
@@ -276,13 +276,10 @@ function getTextualContent(declaration: CSSStyleDeclaration): string {
  * @param root
  * @param context
  */
-export function computeAccessibleName(
-	root: Element,
-	context: { isReferenced?: boolean } = {}
-): string {
+export function computeAccessibleName(root: Element): string {
 	const consultedNodes = new Set<Node>();
 
-	if (prohibitsNaming(root) && !context.isReferenced) {
+	if (prohibitsNaming(root)) {
 		return "" as FlatString;
 	}
 


### PR DESCRIPTION
We can't call the actual algorithm recursively since this removes the notion of a root node.