### PR TITLE
chore: Use named function for presentational check

### DIFF
--- a/sources/accessible-name.ts
+++ b/sources/accessible-name.ts
@@ -454,7 +454,7 @@ export function computeAccessibleName(
 			}
 
 			// 2D
-			if (!hasAnyConcreteRoles(current, ["none", "presentation"])) {
+			if (!isMarkedPresentational(current)) {
 				const elementTextAlternative = computeElementTextAlternative(current);
 				if (elementTextAlternative !== null) {
 					consultedNodes.add(current);


### PR DESCRIPTION
Function was already present (but unused). Seems trivial but without using a named function I would add a comment.