### PR TITLE
chore: Document label descendant confusion

### DIFF
--- a/sources/accessible-name.ts
+++ b/sources/accessible-name.ts
@@ -374,6 +374,7 @@ export function computeAccessibleName(root: Element): string {
 		}
 
 		// special casing, cheating to make tests pass
+		// https://github.com/w3c/accname/issues/67
 		if (hasAnyConcreteRoles(current, ["menu"])) {
 			consultedNodes.add(current);
 			return "";
@@ -473,7 +474,7 @@ export function computeAccessibleName(root: Element): string {
 			}
 		}
 
-		// 2F
+		// 2F: https://w3c.github.io/accname/#step2F
 		if (
 			allowsNameFromContent(current) ||
 			(isElement(current) && context.isReferenced) ||


### PR DESCRIPTION
Commit that added it (2da473717768a945ed250a685304183c488c65f2) does not include the fixed test. Testing which one it is.

IMO the `menu` should be considered since it is a 
>  descendant of a native host language text alternative element

Ref: https://github.com/w3c/accname/issues/67