### PR TITLE
feat: Allow mocking getComputedStyle

### DIFF
--- a/.changeset/lemon-pets-cover.md
+++ b/.changeset/lemon-pets-cover.md
@@ -1,0 +1,11 @@
+---
+"dom-accessibility-api": minor
+---
+
+Add option to mock window.getComputedStyle
+
+This option has two use cases in mind:
+
+1. fake the style and assume everything is visible.
+   This increases performance (window.getComputedStyle) is expensive) by not distinguishing between various levels of visual impairments. If one can't see the name with a screen reader then neither will a sighted user
+2. Wrap a cache provider around `window.getComputedStyle`. We don't implement any because the returned `CSSStyleDeclaration` is only live in a browser. `jsdom` does not implement live declarations.

--- a/sources/__tests__/accessible-name.js
+++ b/sources/__tests__/accessible-name.js
@@ -358,3 +358,40 @@ describe("prohibited naming", () => {
 		}
 	);
 });
+
+describe("options.getComputedStyle", () => {
+	beforeEach(() => {
+		jest.spyOn(window, "getComputedStyle");
+	});
+
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
+	it("uses window.getComputedStyle by default", () => {
+		const container = renderIntoDocument("<button>test</button>");
+
+		computeAccessibleName(container.querySelector("button"));
+
+		// also mixing in a regression test for the number of calls
+		expect(window.getComputedStyle).toHaveBeenCalledTimes(4);
+	});
+
+	it("can be mocked with a fake", () => {
+		const container = renderIntoDocument("<button>test</button>");
+
+		const name = computeAccessibleName(container.querySelector("button"), {
+			getComputedStyle: () => {
+				const declaration = new CSSStyleDeclaration();
+				declaration.content = "'foo'";
+				declaration.display = "block";
+				declaration.visibility = "visible";
+
+				return declaration;
+			}
+		});
+
+		expect(name).toEqual("foo test foo");
+		expect(window.getComputedStyle).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
`window.getComputedStyle` is very expensive. To address performance concerns this PR allows mocking this function out. 

One could mock a fake implementation that returns always visible elements. The neat part is that is puts users with and without visual impairment on the same level. If your test makes assertions about elements that are visually hidden then even sighted users won't be able to perform it.

Another use case would be wrapping `window.getComputedStyle` with a caching provider. It's unclear if we should allow providing a factory instead so that cache busting is easier (simply clear it before every call) or if this is responsibility in userland. Either way a factory option can be added later and I want to see usage first.