### PR TITLE
feat: export mjs and cjs

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -13,8 +13,9 @@ module.exports = {
 			plugins: [
 				[
 					require.resolve("@babel/plugin-transform-modules-commonjs"),
-					// helps rollup identify exports
-					{ loose: true, strict: true }
+					// helps rollup identify exports but also means __esmodule is enumerated
+					// not aware of a use case for enumerating imports though
+					{ loose: true }
 				]
 			]
 		}

--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,6 +1,11 @@
 module.exports = {
 	presets: [
-		[require.resolve("@babel/preset-env"), { modules: false }],
+		[
+			require.resolve("@babel/preset-env"),
+			// for jest we need to transpile esmodules
+			// otherwise transform-commonjs takes care of the correct module syntax
+			{ modules: process.env.NODE_ENV === "test" ? "auto" : false }
+		],
 		require.resolve("@babel/preset-typescript")
 	],
 	env: {

--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,6 +1,17 @@
 module.exports = {
 	presets: [
-		require.resolve("@babel/preset-env"),
+		[require.resolve("@babel/preset-env"), { modules: false }],
 		require.resolve("@babel/preset-typescript")
-	]
+	],
+	env: {
+		cjs: {
+			plugins: [
+				[
+					require.resolve("@babel/plugin-transform-modules-commonjs"),
+					// helps rollup identify exports
+					{ loose: true, strict: true }
+				]
+			]
+		}
+	}
 };

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,5 +1,5 @@
 {
-	"buildCommand": "build:source",
+	"buildCommand": "build",
 	"sandboxes": ["new"],
 	"silent": true
 }

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tests/cypress/videos
 /junit.xml
 /coverage
 /yarn-error.log
+/dom-accessibility-api.tgz

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,6 +35,15 @@ steps:
       yarn build
     displayName: "Build"
 
+  - script: |
+      npm pack
+      mv dom-accessibility-api-*.tgz dom-accessibility-api.tgz
+    displayName: "Prepare smoke tests of build"
+
+  - script: yarn start
+    displayName: "kcd-rollup smoke tests of build"
+    workingDirectory: tests/build/fixtures/kcd-rollup
+
   - script: yarn test:ci
     displayName: "Run jest tests"
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,11 @@
 	"name": "dom-accessibility-api",
 	"version": "0.4.1",
 	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"type": "commonjs",
+	"exports": {
+		"import": "dist/index.mjs",
+		"require": "dist/index.js"
+	},
 	"license": "MIT",
 	"repository": {
 		"type": "git",
@@ -16,9 +20,10 @@
 		"dist/"
 	],
 	"scripts": {
-		"build": "yarn build:clean && yarn build:source && yarn build:types",
+		"build": "yarn build:clean && yarn build:source && yarn build:source:cjs && yarn build:types",
 		"build:clean": "rimraf dist",
-		"build:source": "babel sources --extensions \".ts\" --ignore \"**/__tests__/**/*\" --out-dir dist/ --source-maps",
+		"build:source": "babel sources --extensions \".ts\" --ignore \"**/__tests__/**/*\" --out-dir dist/ --out-file-extension=.mjs --source-maps",
+		"build:source:cjs": "cross-env BABEL_ENV=cjs babel sources --extensions \".ts\" --ignore \"**/__tests__/**/*\" --out-dir dist/ --out-file-extension=.js --source-maps",
 		"build:types": "tsc -p tsconfig.json --emitDeclarationOnly",
 		"format": "prettier \"**/*.{json,js,md,ts,yml}\" --write --ignore-path .prettierignore",
 		"lint": "eslint --report-unused-disable-directives \"sources/**/*.ts\"",
@@ -40,6 +45,7 @@
 	"devDependencies": {
 		"@babel/cli": "^7.8.4",
 		"@babel/core": "^7.8.7",
+		"@babel/plugin-transform-modules-commonjs": "^7.9.0",
 		"@babel/preset-env": "^7.8.7",
 		"@babel/preset-typescript": "^7.8.3",
 		"@changesets/changelog-github": "^0.2.2",
@@ -49,6 +55,7 @@
 		"@typescript-eslint/eslint-plugin": "^2.23.0",
 		"@typescript-eslint/parser": "^2.23.0",
 		"concurrently": "^5.1.0",
+		"cross-env": "^7.0.2",
 		"cypress": "^4.1.0",
 		"eslint": "^6.8.0",
 		"jest": "^25.1.0",

--- a/tests/build/fixtures/kcd-rollup/.gitignore
+++ b/tests/build/fixtures/kcd-rollup/.gitignore
@@ -1,0 +1,3 @@
+# kcd scripts output
+dist/
+yarn.lock

--- a/tests/build/fixtures/kcd-rollup/README.md
+++ b/tests/build/fixtures/kcd-rollup/README.md
@@ -1,0 +1,3 @@
+# kdc-rollup
+
+How `@testing-library/dom` builds.

--- a/tests/build/fixtures/kcd-rollup/package.json
+++ b/tests/build/fixtures/kcd-rollup/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "build-fixture-kcd-rollup",
+	"private": true,
+	"dependencies": {
+		"dom-accessibility-api": "file:../../../../dom-accessibility-api.tgz",
+		"kcd-scripts": "^5.5.0"
+	},
+	"scripts": {
+		"start": "yarn install --no-lockfile && yarn build",
+		"build": "kcd-scripts build --bundle --no-clean"
+	}
+}

--- a/tests/build/fixtures/kcd-rollup/rollup.config.js
+++ b/tests/build/fixtures/kcd-rollup/rollup.config.js
@@ -1,0 +1,5 @@
+const rollupConfig = require("kcd-scripts/dist/config/rollup.config");
+
+// the exports in this library should always be named for all formats.
+rollupConfig.output[0].exports = "named";
+module.exports = rollupConfig;

--- a/tests/build/fixtures/kcd-rollup/src/index.js
+++ b/tests/build/fixtures/kcd-rollup/src/index.js
@@ -1,0 +1,5 @@
+import { computeAccessibleName } from "dom-accessibility-api";
+
+if (typeof computeAccessibleName !== "function") {
+	throw new TypeError();
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -186,6 +186,19 @@
     "@babel/types" "^7.8.3"
     lodash "^4.17.13"
 
+"@babel/helper-module-transforms@^7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz#43b34dfe15961918707d247327431388e9fe96e5"
+  integrity sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==
+  dependencies:
+    "@babel/helper-module-imports" "^7.8.3"
+    "@babel/helper-replace-supers" "^7.8.6"
+    "@babel/helper-simple-access" "^7.8.3"
+    "@babel/helper-split-export-declaration" "^7.8.3"
+    "@babel/template" "^7.8.6"
+    "@babel/types" "^7.9.0"
+    lodash "^4.17.13"
+
 "@babel/helper-optimise-call-expression@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz#7ed071813d09c75298ef4f208956006b6111ecb9"
@@ -250,6 +263,11 @@
   integrity sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==
   dependencies:
     "@babel/types" "^7.8.3"
+
+"@babel/helper-validator-identifier@^7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.0.tgz#ad53562a7fc29b3b9a91bbf7d10397fd146346ed"
+  integrity sha512-6G8bQKjOh+of4PV/ThDm/rRqlU7+IGoJuofpagU5GlEl29Vv0RGqqt86ZGRV8ZuSOY3o+8yXl5y782SMcG7SHw==
 
 "@babel/helper-wrap-function@^7.8.3":
   version "7.8.3"
@@ -549,6 +567,16 @@
     "@babel/helper-simple-access" "^7.8.3"
     babel-plugin-dynamic-import-node "^2.3.0"
 
+"@babel/plugin-transform-modules-commonjs@^7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.9.0.tgz#e3e72f4cbc9b4a260e30be0ea59bdf5a39748940"
+  integrity sha512-qzlCrLnKqio4SlgJ6FMMLBe4bySNis8DFn1VkGmOcxG9gqEyPIOzeQrA//u0HAKrWpJlpZbZMPB1n/OPa4+n8g==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.9.0"
+    "@babel/helper-plugin-utils" "^7.8.3"
+    "@babel/helper-simple-access" "^7.8.3"
+    babel-plugin-dynamic-import-node "^2.3.0"
+
 "@babel/plugin-transform-modules-systemjs@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.8.3.tgz#d8bbf222c1dbe3661f440f2f00c16e9bb7d0d420"
@@ -789,6 +817,15 @@
   integrity sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==
   dependencies:
     esutils "^2.0.2"
+    lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.9.0.tgz#00b064c3df83ad32b2dbf5ff07312b15c7f1efb5"
+  integrity sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.9.0"
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
@@ -2338,6 +2375,13 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
+cross-env@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.2.tgz#bd5ed31339a93a3418ac4f3ca9ca3403082ae5f9"
+  integrity sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -2358,7 +2402,7 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.0:
+cross-spawn@^7.0.0, cross-spawn@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.1.tgz#0ab56286e0f7c24e153d04cc2aa027e43a9a5d14"
   integrity sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==


### PR DESCRIPTION
replaces interop cjs.

Most if this code is so that it works with the kcd-scripts rollup config when building for UMD. I don't know why that one uses cjs.