### PR TITLE
feat: Add module field

### DIFF
--- a/.changeset/many-waves-hear.md
+++ b/.changeset/many-waves-hear.md
@@ -1,0 +1,5 @@
+---
+"dom-accessibility-api": minor
+---
+
+Add `module` field

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
 	"name": "dom-accessibility-api",
 	"version": "0.4.3",
 	"main": "dist/index.js",
+	"module": "dist/index.mjs",
 	"type": "commonjs",
 	"exports": {
 		"import": "./dist/index.mjs",


### PR DESCRIPTION
Older bundlers still need the `module` field. `exports` is for new one.

Hopefully fixes https://github.com/eps1lon/dom-accessibility-api/pull/168#issuecomment-608168905