### PR TITLE
test: Add build test for ava+ts-node

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,6 +57,10 @@ steps:
     workingDirectory: tests/build/fixtures/kcd-rollup
 
   - script: yarn start
+    displayName: "ava+ts-node smoke tests of build"
+    workingDirectory: tests/build/fixtures/ava-ts-node
+
+  - script: yarn start
     displayName: "ES modules in node smoke tests of build"
     workingDirectory: tests/build/fixtures/node-es-modules
     # in node 12 we need to use a flag and I'm to lazy to branch even further

--- a/tests/build/fixtures/ava-ts-node/package.json
+++ b/tests/build/fixtures/ava-ts-node/package.json
@@ -1,0 +1,29 @@
+{
+	"name": "build-fixture-node-es-modules",
+	"private": true,
+	"dependencies": {
+		"@testing-library/react": "^10.0.2",
+		"@types/jsdom": "^16.2.1",
+		"@types/testing-library__react": "^10.0.1",
+		"ava": "^3.6.0",
+		"jsdom": "^16.2.2",
+		"react": "^16.13.1",
+		"react-dom": "^16.13.1",
+		"ts-node": "^8.8.2",
+		"typescript": "^3.8.3"
+	},
+	"resolutions": {
+		"**/dom-accessibility-api": "file:../../../../dom-accessibility-api.tgz"
+	},
+	"scripts": {
+		"start": "yarn install --no-lockfile && yarn ava test.ts"
+	},
+	"ava": {
+		"extensions": [
+			"ts"
+		],
+		"require": [
+			"ts-node/register"
+		]
+	}
+}

--- a/tests/build/fixtures/ava-ts-node/test.ts
+++ b/tests/build/fixtures/ava-ts-node/test.ts
@@ -1,0 +1,21 @@
+import test from "ava";
+import { JSDOM } from "jsdom";
+import { getByRole } from "@testing-library/react";
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+
+test("fn() returns foo", (t) => {
+	const { window } = new JSDOM();
+	// @ts-ignore
+	global.window = window;
+	// @ts-ignore
+	global.document = window.document;
+
+	const container = document.createElement("div");
+	ReactDOM.render(
+		React.createElement("div", { children: "Hello, Dave!", role: "button" }),
+		container
+	);
+	// getByRole depends on `dom-accessibility-api`
+	t.truthy(getByRole(container, "button", { name: "Hello, Dave!" }));
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -65,5 +65,6 @@
 		// "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
 		// "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
 		"skipLibCheck": false
-	}
+	},
+	"include": ["sources/**/*.ts"]
 }


### PR DESCRIPTION
Trying reproduce https://github.com/eps1lon/dom-accessibility-api/pull/168#issuecomment-608168905.

Either this isn't the same setup or this was fixed in the meantime. @jamiebuilds Do you still have issues with `dom-accessibility-api`?