### PR TITLE
chore: document wpt vs accname conflict concerning child nodes

### DIFF
--- a/.changeset/five-pillows-sing.md
+++ b/.changeset/five-pillows-sing.md
@@ -4,5 +4,5 @@
 
 Don't consider elements referenced via `aria-owns` as child nodes.
 
-`accname` does not mentioned "owned elements" in the algorithm. 
+`accname` does not mentioned "owned elements" in the algorithm.
 If you relied on this behavior please open an issue.

--- a/.changeset/five-pillows-sing.md
+++ b/.changeset/five-pillows-sing.md
@@ -1,8 +1,0 @@
----
-"dom-accessibility-api": patch
----
-
-Don't consider elements referenced via `aria-owns` as child nodes.
-
-`accname` does not mentioned "owned elements" in the algorithm.
-If you relied on this behavior please open an issue.

--- a/.changeset/five-pillows-sing.md
+++ b/.changeset/five-pillows-sing.md
@@ -1,0 +1,8 @@
+---
+"dom-accessibility-api": patch
+---
+
+Don't consider elements referenced via `aria-owns` as child nodes.
+
+`accname` does not mentioned "owned elements" in the algorithm. 
+If you relied on this behavior please open an issue.

--- a/sources/accessible-name.ts
+++ b/sources/accessible-name.ts
@@ -133,15 +133,6 @@ function idRefs(node: Node, attributeName: string): Element[] {
 }
 
 /**
- * All defined children. This include childNodes as well as owned (portaled) trees
- * via aria-owns
- * @param node
- */
-function queryChildNodes(node: Node): Node[] {
-	return ArrayFrom(node.childNodes).concat(idRefs(node, "aria-owns"));
-}
-
-/**
  * @param {Node} node -
  * @returns {boolean} - As defined in step 2E of https://w3c.github.io/accname/#mapping_additional_nd_te
  */
@@ -315,7 +306,12 @@ export function computeAccessibleName(
 			accumulatedText = `${beforeContent} ${accumulatedText}`;
 		}
 
-		for (const child of queryChildNodes(node)) {
+		// FIXME: This is not defined in the spec
+		// But it is required in the web-platform-test
+		const childNodes = ArrayFrom(node.childNodes).concat(
+			idRefs(node, "aria-owns")
+		);
+		for (const child of childNodes) {
 			const result = computeTextAlternative(child, {
 				isEmbeddedInLabel: context.isEmbeddedInLabel,
 				isReferenced: false,

--- a/sources/accessible-name.ts
+++ b/sources/accessible-name.ts
@@ -133,15 +133,6 @@ function idRefs(node: Node, attributeName: string): Element[] {
 }
 
 /**
- * All defined children. This include childNodes as well as owned (portaled) trees
- * via aria-owns
- * @param node
- */
-function queryChildNodes(node: Node): Node[] {
-	return ArrayFrom(node.childNodes).concat(idRefs(node, "aria-owns"));
-}
-
-/**
  * @param {Node} node -
  * @returns {boolean} - As defined in step 2E of https://w3c.github.io/accname/#mapping_additional_nd_te
  */
@@ -315,7 +306,7 @@ export function computeAccessibleName(
 			accumulatedText = `${beforeContent} ${accumulatedText}`;
 		}
 
-		for (const child of queryChildNodes(node)) {
+		for (const child of ArrayFrom(node.childNodes)) {
 			const result = computeTextAlternative(child, {
 				isEmbeddedInLabel: context.isEmbeddedInLabel,
 				isReferenced: false,

--- a/sources/accessible-name.ts
+++ b/sources/accessible-name.ts
@@ -133,6 +133,15 @@ function idRefs(node: Node, attributeName: string): Element[] {
 }
 
 /**
+ * All defined children. This include childNodes as well as owned (portaled) trees
+ * via aria-owns
+ * @param node
+ */
+function queryChildNodes(node: Node): Node[] {
+	return ArrayFrom(node.childNodes).concat(idRefs(node, "aria-owns"));
+}
+
+/**
  * @param {Node} node -
  * @returns {boolean} - As defined in step 2E of https://w3c.github.io/accname/#mapping_additional_nd_te
  */
@@ -306,7 +315,7 @@ export function computeAccessibleName(
 			accumulatedText = `${beforeContent} ${accumulatedText}`;
 		}
 
-		for (const child of ArrayFrom(node.childNodes)) {
+		for (const child of queryChildNodes(node)) {
 			const result = computeTextAlternative(child, {
 				isEmbeddedInLabel: context.isEmbeddedInLabel,
 				isReferenced: false,


### PR DESCRIPTION
The name for this method was inappropriate anyway (`queryChildNodes` when it considered owned elements). Realized the spec never mentions owned elements in the name computation of children so it seems safe to remove.