### PR TITLE
feat: reduce transpilation helpers

### DIFF
--- a/.changeset/poor-ways-film.md
+++ b/.changeset/poor-ways-film.md
@@ -1,0 +1,12 @@
+---
+"dom-accessibility-api": patch
+---
+
+Reduce over-transpilation
+
+Switched from
+
+- for-of to `.forEach` or basic for loop
+- `array.push(...otherArray)` to `push.apply(array, otherArray)`
+
+This removed a bunch of babel junk that wasn't needed.

--- a/.eslintrc
+++ b/.eslintrc
@@ -26,6 +26,13 @@
 				// own implementation. See https://github.com/eps1lon/dom-accessibility-api/blob/eb868428a31a093aecc531bf2dd17e8547bd0c3b/sources/accessible-name.ts#L33
 				"property": "getComputedStyle"
 			}
+		],
+		"no-restricted-syntax": [
+			"error",
+			{
+				"selector": "ForOfStatement",
+				"message": "for-of assumes iterators which require heavy transpilation for es5. Use ArrayFrom(...).forEach instead."
+			}
 		]
 	},
 	"overrides": [
@@ -48,7 +55,10 @@
 				// disable previous window.getComputedStyles restriction
 				// perf concerns for this aren't applicable to test
 				// since we specifically want to test them
-				"no-restricted-properties": "off"
+				"no-restricted-properties": "off",
+				// disable previous for-of restriction
+				// over transpilation isn't a concern for tests
+				"no-restricted-syntax": "off"
 			}
 		}
 	]

--- a/.eslintrc
+++ b/.eslintrc
@@ -33,7 +33,11 @@
 				"selector": "ForOfStatement",
 				"message": "for-of assumes iterators which require heavy transpilation for es5. Use ArrayFrom(...).forEach instead."
 			}
-		]
+		],
+		// Babel transpiles array spread assuming iterators.
+		// If we know we have an array we cann use .apply instead.
+		// TypeScript will validate that claim.
+		"prefer-spread": "off"
 	},
 	"overrides": [
 		{

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,7 +67,7 @@ steps:
       mkdir $(Agent.TempDirectory)/published-current
       tar xfz $(Agent.TempDirectory)/artifacts-master/dom-accessibility-api.tgz --directory $(Agent.TempDirectory)/published-previous
       tar xfz $(System.DefaultWorkingDirectory)/dom-accessibility-api.tgz --directory $(Agent.TempDirectory)/published-current
-      diff -r $(Agent.TempDirectory)/published-previous $(Agent.TempDirectory)/published-current
+      git --no-pager diff --no-index $(Agent.TempDirectory)/published-previous $(Agent.TempDirectory)/published-current
     displayName: "Diff tarballs"
 
   - script: yarn start

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,9 +65,9 @@ steps:
   - script: |
       mkdir $(Agent.TempDirectory)/published-previous
       mkdir $(Agent.TempDirectory)/published-current
-      tar xfvz $(Agent.TempDirectory)/artifacts-master/dom-accessibility-api.tgz --directory $(Agent.TempDirectory)/published-previous
-      tar xfvz $(System.DefaultWorkingDirectory)/dom-accessibility-api.tgz --directory $(Agent.TempDirectory)/published-current
-      diff $(Agent.TempDirectory)/published-previous $(Agent.TempDirectory)/published-current
+      tar xfz $(Agent.TempDirectory)/artifacts-master/dom-accessibility-api.tgz --directory $(Agent.TempDirectory)/published-previous
+      tar xfz $(System.DefaultWorkingDirectory)/dom-accessibility-api.tgz --directory $(Agent.TempDirectory)/published-current
+      diff -r $(Agent.TempDirectory)/published-previous $(Agent.TempDirectory)/published-current
     displayName: "Diff tarballs"
 
   - script: yarn start

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,8 +63,6 @@ steps:
       runBranch: refs/heads/master
 
   - script: |
-      ls $(Agent.TempDirectory)/artifacts-master
-      ls
       mkdir $(Agent.TempDirectory)/published-previous
       mkdir $(Agent.TempDirectory)/published-current
       tar xfvz $(Agent.TempDirectory)/artifacts-master/dom-accessibility-api.tgz --directory $(Agent.TempDirectory)/published-previous

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,10 +56,26 @@ steps:
   - script: |
       npm pack
       mv dom-accessibility-api-*.tgz dom-accessibility-api.tgz
-    displayName: "Prepare smoke tests of build"
+    displayName: "Create tarball"
 
   - publish: $(System.DefaultWorkingDirectory)/dom-accessibility-api.tgz
+    displayName: "Publish tarball"
     artifact: dom-accessibility-api-node-$(node_version)
+
+  - download: specific
+    displayName: "Download tarball from master"
+    artifact: dom-accessibility-api-node-$(node_version)
+    path: $(System.DefaultWorkingDirectory)/dom-accessibility-api-master.tgz
+    runVersion: latestFromBranch
+    runBranch: refs/heads/master
+
+  - script: |
+      mkdir $(Agent.TempDirectory)/published-previous
+      mkdir $(Agent.TempDirectory)/published-current
+      tar xfvz $(System.DefaultWorkingDirectory)/dom-accessibility-api-master.tgz --directory $(Agent.TempDirectory)/published-previous
+      tar xfvz $(System.DefaultWorkingDirectory)/dom-accessibility-api.tgz --directory $(Agent.TempDirectory)/published-current
+      diff $(Agent.TempDirectory)/published-previous $(Agent.TempDirectory)/published-current
+    displayName: "Diff tarballs"
 
   - script: yarn start
     displayName: "kcd-rollup smoke tests of build"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,7 +67,10 @@ steps:
       mkdir $(Agent.TempDirectory)/published-current
       tar xfz $(Agent.TempDirectory)/artifacts-master/dom-accessibility-api.tgz --directory $(Agent.TempDirectory)/published-previous
       tar xfz $(System.DefaultWorkingDirectory)/dom-accessibility-api.tgz --directory $(Agent.TempDirectory)/published-current
-      git --no-pager diff --no-index $(Agent.TempDirectory)/published-previous $(Agent.TempDirectory)/published-current
+    # --no-index implies --exit-code
+    # This task is informative only.
+    # Diffs are almost always expected
+      git --no-pager diff --no-index $(Agent.TempDirectory)/published-previous $(Agent.TempDirectory)/published-current || exit 0
     displayName: "Diff tarballs"
 
   - script: yarn start

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -68,6 +68,8 @@ steps:
       artifact: dom-accessibility-api-node-$(node_version)
       path: $(System.DefaultWorkingDirectory)/dom-accessibility-api-master.tgz
       source: specific
+      pipeline: $(System.DefinitionId)
+      project: $(System.TeamProject)
       runVersion: latestFromBranch
       runBranch: refs/heads/master
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,17 +39,6 @@ steps:
     displayName: "Install packages"
 
   - script: |
-      yarn format
-      git diff --exit-code
-    displayName: "Check format"
-
-  - script: yarn lint
-    displayName: "Lint code"
-
-  - script: yarn test:types
-    displayName: "Test types"
-
-  - script: |
       yarn build
     displayName: "Build"
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,7 +70,7 @@ steps:
       # --no-index implies --exit-code
       # This task is informative only.
       # Diffs are almost always expected
-      git --no-pager diff --no-index $(Agent.TempDirectory)/published-previous $(Agent.TempDirectory)/published-current || exit 0
+      git --no-pager diff --color --no-index $(Agent.TempDirectory)/published-previous $(Agent.TempDirectory)/published-current || exit 0
     displayName: "Diff tarballs"
 
   - script: yarn start

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,9 +67,9 @@ steps:
       mkdir $(Agent.TempDirectory)/published-current
       tar xfz $(Agent.TempDirectory)/artifacts-master/dom-accessibility-api.tgz --directory $(Agent.TempDirectory)/published-previous
       tar xfz $(System.DefaultWorkingDirectory)/dom-accessibility-api.tgz --directory $(Agent.TempDirectory)/published-current
-    # --no-index implies --exit-code
-    # This task is informative only.
-    # Diffs are almost always expected
+      # --no-index implies --exit-code
+      # This task is informative only.
+      # Diffs are almost always expected
       git --no-pager diff --no-index $(Agent.TempDirectory)/published-previous $(Agent.TempDirectory)/published-current || exit 0
     displayName: "Diff tarballs"
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,12 +62,14 @@ steps:
     displayName: "Publish tarball"
     artifact: dom-accessibility-api-node-$(node_version)
 
-  - download: specific
+  - task: DownloadPipelineArtifact@2
     displayName: "Download tarball from master"
-    artifact: dom-accessibility-api-node-$(node_version)
-    path: $(System.DefaultWorkingDirectory)/dom-accessibility-api-master.tgz
-    runVersion: latestFromBranch
-    runBranch: refs/heads/master
+    inputs:
+      artifact: dom-accessibility-api-node-$(node_version)
+      path: $(System.DefaultWorkingDirectory)/dom-accessibility-api-master.tgz
+      source: specific
+      runVersion: latestFromBranch
+      runBranch: refs/heads/master
 
   - script: |
       mkdir $(Agent.TempDirectory)/published-previous

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,7 +66,7 @@ steps:
     displayName: "Download tarball from master"
     inputs:
       artifact: dom-accessibility-api-node-$(node_version)
-      path: $(System.DefaultWorkingDirectory)/dom-accessibility-api-master.tgz
+      path: $(Agent.TempDirectory)/artifacts-master
       source: specific
       pipeline: $(System.DefinitionId)
       project: $(System.TeamProject)
@@ -74,9 +74,11 @@ steps:
       runBranch: refs/heads/master
 
   - script: |
+      ls $(Agent.TempDirectory)/artifacts-master
+      ls
       mkdir $(Agent.TempDirectory)/published-previous
       mkdir $(Agent.TempDirectory)/published-current
-      tar xfvz $(System.DefaultWorkingDirectory)/dom-accessibility-api-master.tgz --directory $(Agent.TempDirectory)/published-previous
+      tar xfvz $(Agent.TempDirectory)/artifacts-master/dom-accessibility-api.tgz --directory $(Agent.TempDirectory)/published-previous
       tar xfvz $(System.DefaultWorkingDirectory)/dom-accessibility-api.tgz --directory $(Agent.TempDirectory)/published-current
       diff $(Agent.TempDirectory)/published-previous $(Agent.TempDirectory)/published-current
     displayName: "Diff tarballs"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,6 +39,17 @@ steps:
     displayName: "Install packages"
 
   - script: |
+      yarn format
+      git diff --exit-code
+    displayName: "Check format"
+
+  - script: yarn lint
+    displayName: "Lint code"
+
+  - script: yarn test:types
+    displayName: "Test types"
+
+  - script: |
       yarn build
     displayName: "Build"
 

--- a/sources/accessible-name.ts
+++ b/sources/accessible-name.ts
@@ -186,7 +186,8 @@ function querySelectorAllSubtree(
 	const elements = ArrayFrom(element.querySelectorAll(selectors));
 
 	idRefs(element, "aria-owns").forEach((root) => {
-		elements.push(...ArrayFrom(root.querySelectorAll(selectors)));
+		// babel transpiles this assuming an iterator
+		elements.push.apply(elements, ArrayFrom(root.querySelectorAll(selectors)));
 	});
 
 	return elements;

--- a/sources/accessible-name.ts
+++ b/sources/accessible-name.ts
@@ -314,7 +314,7 @@ export function computeAccessibleName(
 		const childNodes = ArrayFrom(node.childNodes).concat(
 			idRefs(node, "aria-owns")
 		);
-		for (const child of childNodes) {
+		childNodes.forEach((child) => {
 			const result = computeTextAlternative(child, {
 				isEmbeddedInLabel: context.isEmbeddedInLabel,
 				isReferenced: false,
@@ -326,7 +326,7 @@ export function computeAccessibleName(
 				createGetComputedStyle(node, options)(node).getPropertyValue("display");
 			const separator = display !== "inline" ? " " : "";
 			accumulatedText += `${separator}${result}`;
-		}
+		});
 
 		if (isElement(node)) {
 			const pseudoAfter = createGetComputedStyle(node, options)(node, ":after");
@@ -366,7 +366,9 @@ export function computeAccessibleName(
 		// https://w3c.github.io/html-aam/#fieldset-and-legend-elements
 		if (isHTMLFieldSetElement(node)) {
 			consultedNodes.add(node);
-			for (const child of ArrayFrom(node.childNodes)) {
+			const children = ArrayFrom(node.childNodes);
+			for (let i = 0; i < children.length; i += 1) {
+				const child = children[i];
 				if (isHTMLLegendElement(child)) {
 					return computeTextAlternative(child, {
 						isEmbeddedInLabel: false,

--- a/sources/accessible-name.ts
+++ b/sources/accessible-name.ts
@@ -183,11 +183,11 @@ function querySelectorAllSubtree(
 	element: Element,
 	selectors: string
 ): Element[] {
-	const elements = [];
+	const elements = ArrayFrom(element.querySelectorAll(selectors));
 
-	for (const root of [element, ...idRefs(element, "aria-owns")]) {
+	idRefs(element, "aria-owns").forEach((root) => {
 		elements.push(...ArrayFrom(root.querySelectorAll(selectors)));
-	}
+	});
 
 	return elements;
 }


### PR DESCRIPTION
- for-of to `.forEach` or basic for loop
- `array.push(...otherArray)` to `push.apply(array, otherArray)`
- add a CI task that prints the diff of the published package