### PR TITLE
chore: Fix azure publish code coverage warning

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -112,7 +112,6 @@ steps:
     inputs:
       codeCoverageTool: Cobertura
       summaryFileLocation: "$(System.DefaultWorkingDirectory)/coverage/*coverage.xml"
-      reportDirectory: "$(System.DefaultWorkingDirectory)/coverage"
 
   - script: |
       yarn wpt:init


### PR DESCRIPTION
Seems like `reportDirectory` is redundant. Might be the reason for this warning.