### PR TITLE
Consider `<title>` for the name of its `<svg>` element.

### DIFF
--- a/.changeset/nine-masks-begin.md
+++ b/.changeset/nine-masks-begin.md
@@ -1,0 +1,5 @@
+---
+"dom-accessibility-api": minor
+---
+
+Consider `<title>` for the name of its `<svg>` element.

--- a/sources/__tests__/accessible-name.js
+++ b/sources/__tests__/accessible-name.js
@@ -301,10 +301,7 @@ test.each([
 		"",
 	],
 	// https://www.w3.org/TR/svg-aam-1.0/
-	[
-		`<svg data-test><title><em>greek</em> rho</title></svg>`,
-		"greek rho",
-	],
+	[`<svg data-test><title><em>greek</em> rho</title></svg>`, "greek rho"],
 ])(`test #%#`, testMarkup);
 
 test("text nodes are not concatenated by space", () => {

--- a/sources/__tests__/accessible-name.js
+++ b/sources/__tests__/accessible-name.js
@@ -300,6 +300,11 @@ test.each([
 		`<table data-test aria-owns="caption"></table><caption id="caption"><em>greek</em> rho</caption>`,
 		"",
 	],
+	// https://www.w3.org/TR/svg-aam-1.0/
+	[
+		`<svg data-test><title><em>greek</em> rho</title></svg>`,
+		"greek rho",
+	],
 ])(`test #%#`, testMarkup);
 
 test("text nodes are not concatenated by space", () => {

--- a/sources/accessible-name-and-description.ts
+++ b/sources/accessible-name-and-description.ts
@@ -14,8 +14,8 @@ import {
 	isHTMLFieldSetElement,
 	isHTMLLegendElement,
 	isHTMLTableElement,
-	isHTMLSvgElement,
-	isHTMLSvgTitleElement,
+	isSVGSVGElement,
+	isSVGTitleElement,
 	queryIdRefs,
 } from "./util";
 
@@ -339,12 +339,12 @@ export function computeTextAlternative(
 		}
 
 		// https://www.w3.org/TR/svg-aam-1.0/
-		if (isHTMLSvgElement(node)) {
+		if (isSVGSVGElement(node)) {
 			consultedNodes.add(node);
 			const children = ArrayFrom(node.childNodes);
 			for (let i = 0; i < children.length; i += 1) {
 				const child = children[i];
-				if (isHTMLSvgTitleElement(child)) {
+				if (isSVGTitleElement(child)) {
 					return child.textContent;
 				}
 			}

--- a/sources/accessible-name-and-description.ts
+++ b/sources/accessible-name-and-description.ts
@@ -14,6 +14,8 @@ import {
 	isHTMLFieldSetElement,
 	isHTMLLegendElement,
 	isHTMLTableElement,
+	isHTMLSvgElement,
+	isHTMLSvgTitleElement,
 	queryIdRefs,
 } from "./util";
 
@@ -331,6 +333,19 @@ export function computeTextAlternative(
 						isReferenced: false,
 						recursion: false,
 					});
+				}
+			}
+			return null;
+		}
+
+		// https://www.w3.org/TR/svg-aam-1.0/
+		if (isHTMLSvgElement(node)) {
+			consultedNodes.add(node);
+			const children = ArrayFrom(node.childNodes);
+			for (let i = 0; i < children.length; i += 1) {
+				const child = children[i];
+				if (isHTMLSvgTitleElement(child)) {
+					return child.textContent;
 				}
 			}
 			return null;

--- a/sources/util.ts
+++ b/sources/util.ts
@@ -56,6 +56,18 @@ export function isHTMLLegendElement(
 	return isElement(node) && node.tagName === "LEGEND";
 }
 
+export function isHTMLSvgElement(
+	node: Node | null
+): node is SVGElement {
+	return isElement(node) && node.tagName === "svg";
+}
+
+export function isHTMLSvgTitleElement(
+	node: Node | null
+): node is SVGTitleElement {
+	return isElement(node) && node.tagName === "title";
+}
+
 /**
  *
  * @param {Node} node -

--- a/sources/util.ts
+++ b/sources/util.ts
@@ -56,14 +56,16 @@ export function isHTMLLegendElement(
 	return isElement(node) && node.tagName === "LEGEND";
 }
 
-export function isHTMLSvgElement(node: Node | null): node is SVGElement {
+export function isSVGElement(node: Node | null): node is SVGElement {
+	return isElement(node) && node.ownerSVGElement !== undefined;
+}
+
+export function isSVGSVGElement(node: Node | null): node is SVGSVGElement {
 	return isElement(node) && node.tagName === "svg";
 }
 
-export function isHTMLSvgTitleElement(
-	node: Node | null
-): node is SVGTitleElement {
-	return isElement(node) && node.tagName === "title";
+export function isSVGTitleElement(node: Node | null): node is SVGTitleElement {
+	return isSVGElement(node) && node.tagName === "title";
 }
 
 /**

--- a/sources/util.ts
+++ b/sources/util.ts
@@ -57,7 +57,7 @@ export function isHTMLLegendElement(
 }
 
 export function isSVGElement(node: Node | null): node is SVGElement {
-	return isElement(node) && node.ownerSVGElement !== undefined;
+	return isElement(node) && (node as any).ownerSVGElement !== undefined;
 }
 
 export function isSVGSVGElement(node: Node | null): node is SVGSVGElement {

--- a/sources/util.ts
+++ b/sources/util.ts
@@ -56,9 +56,7 @@ export function isHTMLLegendElement(
 	return isElement(node) && node.tagName === "LEGEND";
 }
 
-export function isHTMLSvgElement(
-	node: Node | null
-): node is SVGElement {
+export function isHTMLSvgElement(node: Node | null): node is SVGElement {
 	return isElement(node) && node.tagName === "svg";
 }
 


### PR DESCRIPTION
```html
<svg>
  <title>My SVG</title>
</svg>
```

Computing the name for this svg would have returned an empty string previously. It now correctly computes `My SVG` following the [accessible object in the accessibility tree for rendered SVG elements](https://www.w3.org/TR/svg-aam-1.0/#include_elements).

Closes https://github.com/testing-library/dom-testing-library/issues/685