### PR TITLE
test: Remove side-effects from helper utils

### DIFF
--- a/sources/__tests__/accessible-description.js
+++ b/sources/__tests__/accessible-description.js
@@ -1,5 +1,5 @@
 import { computeAccessibleDescription } from "../accessible-description";
-import { renderIntoDocument } from "./helpers/test-utils";
+import { cleanup, renderIntoDocument } from "./helpers/test-utils";
 import { prettyDOM } from "@testing-library/dom";
 import diff from "jest-diff";
 
@@ -46,6 +46,8 @@ function testMarkup(markup, accessibleDescription) {
 	const testNode = container.querySelector("[data-test]");
 	expect(testNode).toHaveAccessibleDescription(accessibleDescription);
 }
+
+afterEach(cleanup);
 
 describe("wpt copies", () => {
 	test.each([

--- a/sources/__tests__/accessible-name.js
+++ b/sources/__tests__/accessible-name.js
@@ -1,5 +1,5 @@
 import { computeAccessibleName } from "../accessible-name";
-import { renderIntoDocument } from "./helpers/test-utils";
+import { cleanup, renderIntoDocument } from "./helpers/test-utils";
 import { prettyDOM } from "@testing-library/dom";
 import diff from "jest-diff";
 
@@ -46,6 +46,8 @@ function testMarkup(markup, accessibleName) {
 	const testNode = container.querySelector("[data-test]");
 	expect(testNode).toHaveAccessibleName(accessibleName);
 }
+
+afterEach(cleanup);
 
 describe("to upstream", () => {
 	// name from content

--- a/sources/__tests__/helpers/test-utils.js
+++ b/sources/__tests__/helpers/test-utils.js
@@ -11,6 +11,4 @@ function cleanup() {
 	document.body.innerHTML = "";
 }
 
-afterEach(cleanup);
-
 export { render, renderIntoDocument, cleanup };


### PR DESCRIPTION
Makes it later easier to reason about `afterEach` order.