### PR TITLE
chore: Cleanup non-null assertions

### DIFF
--- a/sources/accessible-name-and-description.ts
+++ b/sources/accessible-name-and-description.ts
@@ -491,13 +491,11 @@ export function computeTextAlternative(
 			if (hasAbstractRole(current, "range")) {
 				consultedNodes.add(current);
 				if (current.hasAttribute("aria-valuetext")) {
-					// safe due to hasAttribute guard
-					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- safe due to hasAttribute guard
 					return current.getAttribute("aria-valuetext")!;
 				}
 				if (current.hasAttribute("aria-valuenow")) {
-					// safe due to hasAttribute guard
-					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- safe due to hasAttribute guard
 					return current.getAttribute("aria-valuenow")!;
 				}
 				// Otherwise, use the value as specified by a host language attribute.

--- a/sources/getRole.ts
+++ b/sources/getRole.ts
@@ -123,8 +123,7 @@ function getImplicitRole(element: Element): string | null {
 
 function getExplicitRole(element: Element): string | null {
 	if (element.hasAttribute("role")) {
-		// safe due to hasAttribute check
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- safe due to hasAttribute check
 		const [explicitRole] = element.getAttribute("role")!.trim().split(" ");
 		if (explicitRole !== undefined && explicitRole.length > 0) {
 			return explicitRole;

--- a/sources/util.ts
+++ b/sources/util.ts
@@ -76,20 +76,15 @@ export function isSVGTitleElement(node: Node | null): node is SVGTitleElement {
  */
 export function queryIdRefs(node: Node, attributeName: string): Element[] {
 	if (isElement(node) && node.hasAttribute(attributeName)) {
-		// safe due to hasAttribute check
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- safe due to hasAttribute check
 		const ids = node.getAttribute(attributeName)!.split(" ");
 
-		return (
-			ids
-				// safe since it can't be null for an Element
-				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				.map((id) => node.ownerDocument!.getElementById(id))
-				.filter(
-					(element: Element | null): element is Element => element !== null
-					// TODO: why does this not narrow?
-				) as Element[]
-		);
+		return ids
+			.map((id) => node.ownerDocument.getElementById(id))
+			.filter(
+				(element: Element | null): element is Element => element !== null
+				// TODO: why does this not narrow?
+			) as Element[];
 	}
 
 	return [];


### PR DESCRIPTION
- move eslint disable explainer into same line as disable directive (possible since eslint 7)
- Remove unnnecessary non-null assertion