### PR TITLE
fix: accessibility name when title is empty

### DIFF
--- a/.changeset/gentle-lamps-perform.md
+++ b/.changeset/gentle-lamps-perform.md
@@ -1,0 +1,7 @@
+---
+"dom-accessibility-api": patch
+---
+
+Ignore `title` attribute if it is empty.
+
+Previously `<button title="">Hello, Dave!</button>` would wrongly compute an empty name.

--- a/sources/__tests__/accessible-name.js
+++ b/sources/__tests__/accessible-name.js
@@ -304,6 +304,7 @@ test.each([
 	],
 	// https://www.w3.org/TR/svg-aam-1.0/
 	[`<svg data-test><title><em>greek</em> rho</title></svg>`, "greek rho"],
+	[`<button title="" data-test>click me</button>`, "click me"],
 ])(`test #%#`, testMarkup);
 
 test("text nodes are not concatenated by space", () => {

--- a/sources/accessible-name-and-description.ts
+++ b/sources/accessible-name-and-description.ts
@@ -378,7 +378,11 @@ export function computeTextAlternative(
 		}
 
 		const titleAttribute = node.getAttributeNode("title");
-		if (titleAttribute !== null && !consultedNodes.has(titleAttribute)) {
+		if (
+			titleAttribute !== null &&
+			titleAttribute.value.trim() !== "" &&
+			!consultedNodes.has(titleAttribute)
+		) {
 			consultedNodes.add(titleAttribute);
 			return titleAttribute.value;
 		}


### PR DESCRIPTION
fix #393 

If the title is empty ( I have trimmed the text ) it is not considered as accessibility name.

I hope to have done something right :)