### PR TITLE
fix: consider value attribute before localized input type

### DIFF
--- a/.changeset/empty-frogs-attend.md
+++ b/.changeset/empty-frogs-attend.md
@@ -1,0 +1,9 @@
+---
+"dom-accessibility-api": patch
+---
+
+Prefer input value when type is reset or submit.
+
+Previously `<input type="submit" value="Submit values" />` would have a computed accessible name `"Submit"`.
+But the `value` has priority for `reset` and `submit`.
+`computeAccessibleName` now correctly returns `"Submit values"` for these elements.

--- a/.changeset/empty-frogs-attend.md
+++ b/.changeset/empty-frogs-attend.md
@@ -2,8 +2,17 @@
 "dom-accessibility-api": patch
 ---
 
-Prefer input value when type is reset or submit.
+Fix various issues for input types `submit`, `reset` and `image`
 
-Previously `<input type="submit" value="Submit values" />` would have a computed accessible name `"Submit"`.
-But the `value` has priority for `reset` and `submit`.
-`computeAccessibleName` now correctly returns `"Submit values"` for these elements.
+Prefer input `value` when `type` is `reset` or `submit`:
+
+```diff
+<input type="submit" value="Submit values">
+-// accessible name: "Submit"
++// accessible name: "Submit values"
+<input type="reset" value="Reset form">
+-// accessible name: "Reset"
++// accessible name: "Reset form"
+```
+
+For input `type` `image` consider `alt` attribute or fall back to `"Submit query"`.

--- a/.eslintrc
+++ b/.eslintrc
@@ -27,10 +27,16 @@
 				"property": "getComputedStyle"
 			},
 			{
-				// tagName is oftentimes more expensive since it requires a toAsciiUpperCase of the local name.
+				// `tagName` is oftentimes more expensive since it requires a toAsciiUpperCase of the local name.
 				// It certainly is in JSDOM: https://github.com/jsdom/jsdom/pull/3008
 				"property": "tagName",
 				"message": "Please use `getLocalName` instead because `tagName` is oftentimes more expensive since it requires a toAsciiUpperCase of the local name."
+			},
+			{
+				// `localName` is not available in all supported environments.
+				// We have a cross-browser helper with `getLocalName`
+				"property": "localName",
+				"message": "Please use `getLocalName` which implements .localName for older environments."
 			}
 		],
 		"no-restricted-syntax": [

--- a/sources/__tests__/accessible-name.js
+++ b/sources/__tests__/accessible-name.js
@@ -307,6 +307,9 @@ test.each([
 	[`<button title="" data-test>click me</button>`, "click me"],
 	// https://w3c.github.io/html-aam/#input-type-button-input-type-submit-and-input-type-reset-accessible-name-computation
 	[`<input data-test value="Submit form" type="submit" />`, "Submit form"],
+	// https://w3c.github.io/html-aam/#input-type-image
+	[`<input data-test alt="Select an image" type="image" />`, "Select an image"],
+	[`<input data-test alt="" type="image" />`, "Submit Query"],
 ])(`test #%#`, testMarkup);
 
 test("text nodes are not concatenated by space", () => {

--- a/sources/__tests__/accessible-name.js
+++ b/sources/__tests__/accessible-name.js
@@ -305,6 +305,8 @@ test.each([
 	// https://www.w3.org/TR/svg-aam-1.0/
 	[`<svg data-test><title><em>greek</em> rho</title></svg>`, "greek rho"],
 	[`<button title="" data-test>click me</button>`, "click me"],
+	// https://w3c.github.io/html-aam/#input-type-button-input-type-submit-and-input-type-reset-accessible-name-computation
+	[`<input data-test value="Submit form" type="submit" />`, "Submit form"],
 ])(`test #%#`, testMarkup);
 
 test("text nodes are not concatenated by space", () => {

--- a/sources/util.ts
+++ b/sources/util.ts
@@ -6,6 +6,7 @@ import getRole from "./getRole";
  */
 export function getLocalName(element: Element): string {
 	return (
+		// eslint-disable-next-line no-restricted-properties -- actual guard for environments without localName
 		element.localName ??
 		// eslint-disable-next-line no-restricted-properties -- required for the fallback
 		element.tagName.toLowerCase()


### PR DESCRIPTION
I don't think in 

> if the current node's native markup provides an attribute (e.g. title) or element (e.g. HTML label) that defines a text alternative

an order was implied but rather deferred to host specific specs such as `html-aam`. 

Closes #405 

That section of the code is still  quite messy but working.