### PR TITLE
fix: img with missing alt should have role img

### DIFF
--- a/.changeset/light-ladybugs-destroy.md
+++ b/.changeset/light-ladybugs-destroy.md
@@ -2,4 +2,7 @@
 "dom-accessibility-api": patch
 ---
 
-Maintain img role for img with missing alt attribute.
+Maintain `img` role for `img` with missing `alt` attribute.
+
+Previously `<img />` would be treated the same as `<img alt />`.
+`<img />` is now treated as `role="img"` [as specified](https://w3c.github.io/html-aam/#el-img-empty-alt).

--- a/.changeset/light-ladybugs-destroy.md
+++ b/.changeset/light-ladybugs-destroy.md
@@ -1,0 +1,5 @@
+---
+"dom-accessibility-api": patch
+---
+
+Maintain img role for img with missing alt attribute.

--- a/sources/__tests__/getRole.js
+++ b/sources/__tests__/getRole.js
@@ -89,6 +89,7 @@ const cases = [
 	["html", null, createElementFactory("html", {})],
 	["iframe", null, createElementFactory("iframe", {})],
 	["img with alt=\"some text\"", "img", createElementFactory("img", {alt: "text"})],
+	["img with missing alt", "img", createElementFactory("img", {})],
 	["img with alt=\"\"", null, createElementFactory("img", {alt: ""})],
 	["input type=button", "button", createElementFactory("input", {type: "button"})],
 	["input type=checkbox", "checkbox", createElementFactory("input", {type: "checkbox"})],

--- a/sources/getRole.ts
+++ b/sources/getRole.ts
@@ -75,12 +75,13 @@ function getImplicitRole(element: Element): string | null {
 				return "link";
 			}
 			break;
-		case "img":
+		case "img": {
 			const alt: string | null = element.getAttribute("alt");
 			if (alt === null || alt.length > 0) {
 				return "img";
 			}
 			break;
+		}
 		case "input": {
 			const { type } = element as HTMLInputElement;
 			switch (type) {

--- a/sources/getRole.ts
+++ b/sources/getRole.ts
@@ -76,7 +76,8 @@ function getImplicitRole(element: Element): string | null {
 			}
 			break;
 		case "img":
-			if ((element.getAttribute("alt") || "").length > 0) {
+			const alt: string | null = element.getAttribute("alt");
+			if (alt === null || alt.length > 0) {
 				return "img";
 			}
 			break;


### PR DESCRIPTION
- browsers will treat an image with missing alt as an image.
- null alt is different than empty string: empty string removes the node from the AOM, where missing (null) alt does not.
- this change may impact tests that incorrectly rely on missing alt and `alt=''` being equivalent.
- recommend a patch level release.

[fixes #429]