### PR TITLE
test: Publish cypress screenshots only if exists

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -125,9 +125,16 @@ steps:
   - script: yarn test:wpt:browser
     displayName: "Run wpt tests in browser"
 
+  - bash: |
+      if [ -d tests/cypress/screenshots ]; then
+        echo "##vso[task.setVariable variable=CY_SCREENSHOTS_EXIST]true"
+      fi
+    condition: always()
+    displayName: Check if cypress screenshots were created
+
   - publish: tests/cypress/screenshots
     artifact: browser-test-screenshots-node-$(node_version)
-    condition: failed()
+    condition: and(failed(), eq(variables.CY_SCREENSHOTS_EXIST, 'true'))
     displayName: "Publish cypress screenshots"
 
   - publish: tests/cypress/videos

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -111,7 +111,7 @@ steps:
   - task: PublishCodeCoverageResults@1
     inputs:
       codeCoverageTool: Cobertura
-      failIfCoverageEmpty: true
+      failIfCoverageEmpty: true 
       summaryFileLocation: "$(System.DefaultWorkingDirectory)/scripts/jest/coverage/*coverage.xml"
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -128,6 +128,8 @@ steps:
   - bash: |
       if [ -d tests/cypress/screenshots ]; then
         echo "##vso[task.setVariable variable=CY_SCREENSHOTS_EXIST]true"
+      else
+        echo "##vso[task.setVariable variable=CY_SCREENSHOTS_EXIST]false"
       fi
     condition: always()
     displayName: Check if cypress screenshots were created

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -111,7 +111,7 @@ steps:
   - task: PublishCodeCoverageResults@1
     inputs:
       codeCoverageTool: Cobertura
-      failIfCoverageEmpty: true 
+      failIfCoverageEmpty: true
       summaryFileLocation: "$(System.DefaultWorkingDirectory)/scripts/jest/coverage/*coverage.xml"
 
   - script: |


### PR DESCRIPTION
The azure dashboard is a bit busy if the pipeline fails before Cypress started. Parsing what fails is quite difficult since it contains ~40% noise.

We only attempt to publish the screenshots if they were actually created. This is potentially problematic if they erroneously weren't created but then we'll see it in the pipeline. If we never notice then it's indicative we don't need them.