### PR TITLE
fix: determine accname for elements with slots

### DIFF
--- a/.changeset/plenty-crabs-pump.md
+++ b/.changeset/plenty-crabs-pump.md
@@ -1,0 +1,30 @@
+---
+"dom-accessibility-api": patch
+---
+
+Correctly determine accessible name when element contains a slot.
+
+Previously, computing the accessible name would only examine child nodes. However, content placed in a slot is is an assigned node, not a child node. 
+
+If you have a custom element `custom-button` with a slot:
+
+```html
+<button><slot></slot></button>
+
+<!-- accname of inner <button> is 'Custom name' (previously '') -->
+<custom-button>Custom name</custom-button>
+```
+
+If you have a custom element `custom-button-default` with default content in the slot:
+
+```html
+<button><slot>Default name</slot></button>
+
+<!-- accname of inner <button> is 'Custom name' (previously 'Default name') -->
+<custom-button-default>Custom name</custom-button-default>
+
+<!-- accname of inner <button> is 'Default name' (previously 'Default name') -->
+<custom-button-default></custom-button-default>
+```
+
+This is not currently defined in the accname spec but reflects current browser behavior. 

--- a/.changeset/plenty-crabs-pump.md
+++ b/.changeset/plenty-crabs-pump.md
@@ -4,7 +4,7 @@
 
 Correctly determine accessible name when element contains a slot.
 
-Previously, computing the accessible name would only examine child nodes. However, content placed in a slot is is an assigned node, not a child node. 
+Previously, computing the accessible name would only examine child nodes. However, content placed in a slot is is an assigned node, not a child node.
 
 If you have a custom element `custom-button` with a slot:
 
@@ -27,4 +27,4 @@ If you have a custom element `custom-button-default` with default content in the
 <custom-button-default></custom-button-default>
 ```
 
-This is not currently defined in the accname spec but reflects current browser behavior. 
+This is not currently defined in the accname spec but reflects current browser behavior.

--- a/sources/__tests__/accessible-name.js
+++ b/sources/__tests__/accessible-name.js
@@ -50,7 +50,9 @@ function testMarkup(markup, accessibleName) {
 function testShadowDomMarkup(markup, accessibleName) {
 	const container = renderIntoDocument(markup);
 
-	const testNode = container.querySelector("[data-test]").shadowRoot.querySelector('[data-test]');
+	const testNode = container
+		.querySelector("[data-root]")
+		.shadowRoot.querySelector("[data-test]");
 	expect(testNode).toHaveAccessibleName(accessibleName);
 }
 
@@ -226,20 +228,20 @@ describe("slots", () => {
 	test.each([
 		[
 			"no default content",
-			`<custom-button data-test>Custom name</custom-button>`,
+			`<custom-button data-root>Custom name</custom-button>`,
 			"Custom name",
 		],
 		[
 			"default content",
-			`<custom-button-with-default data-test></custom-button>`,
+			`<custom-button-with-default data-root></custom-button>`,
 			"Default name",
 		],
 		[
 			"overridden default content",
-			`<custom-button-with-default data-test>Custom name</custom-button>`,
+			`<custom-button-with-default data-root>Custom name</custom-button>`,
 			"Custom name",
 		],
-	])("slot with %s has name", (_, markup, expectedAccessibleName) => 
+	])("slot with %s has name", (_, markup, expectedAccessibleName) =>
 		testShadowDomMarkup(markup, expectedAccessibleName)
 	);
 });

--- a/sources/accessible-name-and-description.ts
+++ b/sources/accessible-name-and-description.ts
@@ -309,9 +309,12 @@ function getLabels(element: Element): HTMLLabelElement[] | null {
 
 /**
  * Gets the contents of a slot used for computing the accname
- * @param slot 
+ * @param slot
  */
 function getSlotContents(slot: HTMLSlotElement): Node[] {
+	// Computing the accessible name for elements containing slots is not
+	// currently defined in the spec. This implementation reflects the
+	// behavior of NVDA 2020.2/Firefox 81 and iOS VoiceOver/Safari 13.6.
 	const assignedNodes = slot.assignedNodes();
 	if (assignedNodes.length === 0) {
 		// if no nodes are assigned to the slot, it displays the default content
@@ -356,16 +359,11 @@ export function computeTextAlternative(
 			accumulatedText = `${beforeContent} ${accumulatedText}`;
 		}
 
-		// Computing the accessible name for elements containing slots
-		// is not currently defined in the spec. This implementation
-		// reflects current browser behavior.
-		const childNodes = isHTMLSlotElement(node) 
-			? getSlotContents(node) 
-			// FIXME: This is not defined in the spec
-			// But it is required in the web-platform-test
-			: ArrayFrom(node.childNodes).concat(
-				queryIdRefs(node, "aria-owns")
-			);
+		// FIXME: Including aria-owns is not defined in the spec
+		// But it is required in the web-platform-test
+		const childNodes = isHTMLSlotElement(node)
+			? getSlotContents(node)
+			: ArrayFrom(node.childNodes).concat(queryIdRefs(node, "aria-owns"));
 		childNodes.forEach((child) => {
 			const result = computeTextAlternative(child, {
 				isEmbeddedInLabel: context.isEmbeddedInLabel,

--- a/sources/util.ts
+++ b/sources/util.ts
@@ -69,9 +69,7 @@ export function isHTMLLegendElement(
 	return isElement(node) && getLocalName(node) === "legend";
 }
 
-export function isHTMLSlotElement(
-	node: Node | null
-): node is HTMLSlotElement {
+export function isHTMLSlotElement(node: Node | null): node is HTMLSlotElement {
 	return isElement(node) && getLocalName(node) === "slot";
 }
 

--- a/sources/util.ts
+++ b/sources/util.ts
@@ -69,6 +69,12 @@ export function isHTMLLegendElement(
 	return isElement(node) && getLocalName(node) === "legend";
 }
 
+export function isHTMLSlotElement(
+	node: Node | null
+): node is HTMLSlotElement {
+	return isElement(node) && getLocalName(node) === "slot";
+}
+
 export function isSVGElement(node: Node | null): node is SVGElement {
 	return isElement(node) && (node as SVGElement).ownerSVGElement !== undefined;
 }


### PR DESCRIPTION
Correctly determine accessible name when element contains a slot.

Previously, computing the accessible name would only examine child nodes. However, content placed in a slot is is an assigned node, not a child node. If an element is a slot, we now examine either assignedNodes (if content was placed in the slot) or childNodes (the default content of the slot).

Fixes #423