### PR TITLE
docs: Add description for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "dom-accessibility-api",
+	"description": "Implements https://w3c.github.io/accname/",
 	"version": "0.5.4",
 	"main": "dist/index.js",
 	"module": "dist/index.mjs",


### PR DESCRIPTION
When searching on https://www.npmjs.com/ the results include name and description. If no description is provided it uses the first lines from the README which is unreadable because it includes all the badges.