### PR TITLE
test: Prevent ubuntu-20.04 warning

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ pr:
       - "*"
 
 pool:
-  vmImage: "ubuntu-latest"
+  vmImage: "ubuntu-20.04"
 
 # TODO we don't actually need this for karma or cypress tests
 # but it let's us use a single job. No need to split up jobs yet


### PR DESCRIPTION
Looks like builds are not considered for DownloadPipelineArtifact because of the ubuntu-latest warning. Otherwise I can't explain why the task can't find builds.