### PR TITLE
feat: Switch 2C with 2E

### DIFF
--- a/sources/__tests__/accessible-name.js
+++ b/sources/__tests__/accessible-name.js
@@ -376,7 +376,7 @@ test.each([
 		`<img data-test alt="" aria-label="a logo" role="presentation" /> />`,
 		"a logo",
 	],
-])(`test #%#`, (markup, expectedAccessibleName) => {
+])(`misc test #%#`, (markup, expectedAccessibleName) => {
 	expect(markup).toHaveAccessibleName(expectedAccessibleName);
 });
 

--- a/sources/__tests__/accessible-name.js
+++ b/sources/__tests__/accessible-name.js
@@ -5,7 +5,21 @@ import diff from "jest-diff";
 
 expect.extend({
 	toHaveAccessibleName(received, expected) {
-		if (received == null) {
+		let receivedElement = received;
+		if (typeof received === "string") {
+			const markup = received;
+			const container = renderIntoDocument(markup);
+
+			receivedElement = container.querySelector("[data-test]");
+
+			if (receivedElement == null) {
+				return {
+					message: () =>
+						`The following markup did not contain an element matching \`[data-test]\`:\n${markup}`,
+					pass: false,
+				};
+			}
+		} else if (received == null) {
 			return {
 				message: () =>
 					`The element was not an Element but '${String(received)}'`,
@@ -13,12 +27,12 @@ expect.extend({
 			};
 		}
 
-		const actual = computeAccessibleName(received);
+		const actual = computeAccessibleName(receivedElement);
 		if (actual !== expected) {
 			return {
 				message: () =>
 					`expected ${prettyDOM(
-						received
+						receivedElement
 					)} to have accessible name '${expected}' but got '${actual}'\n${diff(
 						expected,
 						actual
@@ -39,13 +53,6 @@ expect.extend({
 		};
 	},
 });
-
-function testMarkup(markup, accessibleName) {
-	const container = renderIntoDocument(markup);
-
-	const testNode = container.querySelector("[data-test]");
-	expect(testNode).toHaveAccessibleName(accessibleName);
-}
 
 function testShadowDomMarkup(markup, accessibleName) {
 	const container = renderIntoDocument(markup);
@@ -132,9 +139,9 @@ describe("to upstream", () => {
 			`<li data-test role="treeitem"><em>greek</em> pi</li>`,
 			"greek pi",
 		],
-	])(`role %s has name from content`, (_, markup, expectedAccessibleName) =>
-		testMarkup(markup, expectedAccessibleName)
-	);
+	])(`role %s has name from content`, (_, markup, expectedAccessibleName) => {
+		expect(markup).toHaveAccessibleName(expectedAccessibleName);
+	});
 
 	test.each([
 		[
@@ -196,7 +203,7 @@ describe("to upstream", () => {
 			"Country of origin: United States",
 		],
 	])(`coverage for %s`, (_, markup, expectedAccessibleName) => {
-		return testMarkup(markup, expectedAccessibleName);
+		expect(markup).toHaveAccessibleName(expectedAccessibleName);
 	});
 });
 
@@ -369,7 +376,9 @@ test.each([
 		`<img data-test alt="" aria-label="a logo" role="presentation" /> />`,
 		"a logo",
 	],
-])(`test #%#`, testMarkup);
+])(`test #%#`, (markup, expectedAccessibleName) => {
+	expect(markup).toHaveAccessibleName(expectedAccessibleName);
+});
 
 test("text nodes are not concatenated by space", () => {
 	// how React would create `<h1>Hello {name}!</h1>`
@@ -398,7 +407,7 @@ describe("prohibited naming", () => {
 		["subscript", '<div data-test role="subscript">named?</div>'],
 		["superscript", "<div data-test role='supscript'>Hello</div>"],
 	])("role '%s' prohibites naming", (_, markup) => {
-		testMarkup(markup, "");
+		expect(markup).toHaveAccessibleName("");
 	});
 
 	test.each([
@@ -462,8 +471,8 @@ describe("prohibited naming", () => {
 		],
 	])(
 		"role '%s'can be part of the accessible name of another element",
-		(_, markup, name) => {
-			testMarkup(markup, name);
+		(_, markup, expectedAccessibleName) => {
+			expect(markup).toHaveAccessibleName(expectedAccessibleName);
 		}
 	);
 });

--- a/sources/accessible-name-and-description.ts
+++ b/sources/accessible-name-and-description.ts
@@ -583,26 +583,6 @@ export function computeTextAlternative(
 		// spec says we should only consider skipping if we have a non-empty label
 		const skipToStep2E =
 			context.recursion && isControl(current) && compute === "name";
-		if (!skipToStep2E) {
-			const ariaLabel = (
-				(isElement(current) && current.getAttribute("aria-label")) ||
-				""
-			).trim();
-			if (ariaLabel !== "" && compute === "name") {
-				consultedNodes.add(current);
-				return ariaLabel;
-			}
-
-			// 2D
-			if (!isMarkedPresentational(current)) {
-				const elementTextAlternative = computeElementTextAlternative(current);
-				if (elementTextAlternative !== null) {
-					consultedNodes.add(current);
-					return elementTextAlternative;
-				}
-			}
-		}
-
 		// 2E
 		if (skipToStep2E || context.isEmbeddedInLabel || context.isReferenced) {
 			if (hasAnyConcreteRoles(current, ["combobox", "listbox"])) {
@@ -638,6 +618,24 @@ export function computeTextAlternative(
 			if (hasAnyConcreteRoles(current, ["textbox"])) {
 				consultedNodes.add(current);
 				return getValueOfTextbox(current);
+			}
+		}
+
+		const ariaLabel = (
+			(isElement(current) && current.getAttribute("aria-label")) ||
+			""
+		).trim();
+		if (ariaLabel !== "" && compute === "name") {
+			consultedNodes.add(current);
+			return ariaLabel;
+		}
+
+		// 2D
+		if (!isMarkedPresentational(current)) {
+			const elementTextAlternative = computeElementTextAlternative(current);
+			if (elementTextAlternative !== null) {
+				consultedNodes.add(current);
+				return elementTextAlternative;
 			}
 		}
 


### PR DESCRIPTION
Testing https://github.com/w3c/accname/issues/96

Had to make some adjustments to the implementation of 2E since we never actually checked that the embedded control is actually referenced by "another widget" (emphasis on **another**).