### PR TITLE
fix: Ensure certain babel helpers aren't required

### DIFF
--- a/.changeset/ninety-suits-applaud.md
+++ b/.changeset/ninety-suits-applaud.md
@@ -1,0 +1,21 @@
+---
+"dom-accessibility-api": patch
+---
+
+Ensure certain babel helpers aren't required
+
+Source:
+
+```diff
+-const [item] = list;
++const item = list[0];
+```
+
+Transpiled:
+
+```diff
+-var _trim$split = list.trim().split(" "),
+-_trim$split2 = _slicedToArray(_trim$split, 1),
+-item = _trim$split2[0]
++var item = list[0];
+```

--- a/sources/getRole.ts
+++ b/sources/getRole.ts
@@ -193,10 +193,12 @@ function getImplicitRole(element: Element): string | null {
 }
 
 function getExplicitRole(element: Element): string | null {
-	if (element.hasAttribute("role")) {
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- safe due to hasAttribute check
-		const [explicitRole] = element.getAttribute("role")!.trim().split(" ");
-		if (explicitRole !== undefined && explicitRole.length > 0) {
+	const role = element.getAttribute("role");
+	if (role !== null) {
+		const explicitRole = role.trim().split(" ")[0];
+		// String.prototype.split(sep, limit) will always return an array with at least one member
+		// as long as limit is either undefined or > 0
+		if (explicitRole.length > 0) {
 			return explicitRole;
 		}
 	}


### PR DESCRIPTION
```diff
-const [item] = list;
+const item = list[0];
```

Also switched from implicit non-null assertion to explicit one.