### PR TITLE
fix: Use label attribute for naming of `<optgroup>`

### DIFF
--- a/.changeset/pretty-tigers-brake.md
+++ b/.changeset/pretty-tigers-brake.md
@@ -1,0 +1,22 @@
+---
+"dom-accessibility-api": patch
+---
+
+Use label attribute for naming of `<optgroup>` elements.
+
+Given
+
+```jsx
+<select>
+	<optgroup label="foo">
+		<option value="1">bar</option>
+	</optgroup>
+</select>
+```
+
+Previously the `<optgroup />` would not have an accessible name.
+Though [2D in `accname` 1.2](https://www.w3.org/TR/accname-1.2/) could be interpreted to use the `label` attribute:
+
+> Otherwise, if the current node's native markup provides an attribute (e.g. title) or element (e.g. HTML label) that defines a text alternative, return that alternative [...]
+
+This was confirmed in NVDA + FireFox.

--- a/sources/__tests__/accessible-name.js
+++ b/sources/__tests__/accessible-name.js
@@ -102,6 +102,11 @@ describe("to upstream", () => {
 			"greek iota",
 		],
 		[
+			"optgroup",
+			`<select><optgroup data-test label="foo"><option value="1">baz</option></optgroup></select>`,
+			"foo",
+		],
+		[
 			"radio",
 			`<div data-test role="radio"><em>greek</em> kappa</div>`,
 			"greek kappa",

--- a/sources/accessible-name-and-description.ts
+++ b/sources/accessible-name-and-description.ts
@@ -13,6 +13,7 @@ import {
 	safeWindow,
 	isHTMLFieldSetElement,
 	isHTMLLegendElement,
+	isHTMLOptGroupElement,
 	isHTMLTableElement,
 	isHTMLSlotElement,
 	isSVGSVGElement,
@@ -461,6 +462,11 @@ export function computeTextAlternative(
 			const nameFromAlt = useAttribute(node, "alt");
 			if (nameFromAlt !== null) {
 				return nameFromAlt;
+			}
+		} else if (isHTMLOptGroupElement(node)) {
+			const nameFromLabel = useAttribute(node, "label");
+			if (nameFromLabel !== null) {
+				return nameFromLabel;
 			}
 		}
 

--- a/sources/util.ts
+++ b/sources/util.ts
@@ -29,6 +29,12 @@ export function isHTMLInputElement(
 	return isElement(node) && getLocalName(node) === "input";
 }
 
+export function isHTMLOptGroupElement(
+	node: Node | null
+): node is HTMLOptGroupElement {
+	return isElement(node) && getLocalName(node) === "optgroup";
+}
+
 export function isHTMLSelectElement(
 	node: Node | null
 ): node is HTMLSelectElement {


### PR DESCRIPTION
Reported in https://github.com/testing-library/dom-testing-library/issues/940