### PR TITLE
chore: Use node 12 in codesandbox/ci

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,5 +1,6 @@
 {
 	"buildCommand": "build",
+	"node": "12",
 	"sandboxes": ["new"],
 	"silent": true
 }


### PR DESCRIPTION
codesandbox still uses node 10 even though it reached EOL