### PR TITLE
chore(renovate): Remove pr-comment

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,5 @@
 {
-	"automerge": true,
-	"automergeType": "pr-comment",
-	"automergeComment": "renovate automerge",
+	"automerge": false,
 	"dependencyDashboard": true,
 	"ignoreDeps": [],
 	"labels": ["dependencies"],


### PR DESCRIPTION
I thought this worked like dependabot i.e. I comment with "automergePrComment" and renovate merges. But the comment is meant for other automation toosl