### PR TITLE
fix: `<th>` has role `rowheader` when `scope` is `row` or `rowgroup`

### DIFF
--- a/.changeset/honest-candles-lick.md
+++ b/.changeset/honest-candles-lick.md
@@ -1,0 +1,6 @@
+---
+"dom-accessibility-api": patch
+---
+
+Previously, the accessible name of `<th>` is columnheader regardless to the scope value.
+It now treat as `rowheader` or `columnheader` by the scope value of `<th>`.

--- a/.changeset/honest-candles-lick.md
+++ b/.changeset/honest-candles-lick.md
@@ -2,5 +2,5 @@
 "dom-accessibility-api": patch
 ---
 
-Previously, the accessible name of `<th>` is columnheader regardless to the scope value.
+Previously, the role of `<th>` is columnheader regardless to the scope value.
 It now treat as `rowheader` or `columnheader` by the scope value of `<th>`.

--- a/sources/__tests__/getRole.js
+++ b/sources/__tests__/getRole.js
@@ -169,6 +169,7 @@ const cases = [
 	["td", "cell", createElementFactory("td", {})],
 	["th", "columnheader", createElementFactory("th", {})],
 	["th, scope=rowgroup", "rowheader", createElementFactory("th", {scope: "rowgroup"})],
+	["th, scope=row", "rowheader", createElementFactory("th", {scope: "row"})],
 	["tr", "row", createElementFactory("tr", {})],
 	["track", null, createElementFactory("track", {})],
 	["ul", "list", createElementFactory("ul", {})],

--- a/sources/__tests__/getRole.js
+++ b/sources/__tests__/getRole.js
@@ -168,6 +168,7 @@ const cases = [
   // WARNING: Only in certain contexts
 	["td", "cell", createElementFactory("td", {})],
 	["th", "columnheader", createElementFactory("th", {})],
+	["th, scope=rowgroup", "rowheader", createElementFactory("th", {scope: "rowgroup"})],
 	["tr", "row", createElementFactory("tr", {})],
 	["track", null, createElementFactory("track", {})],
 	["ul", "list", createElementFactory("ul", {})],

--- a/sources/getRole.ts
+++ b/sources/getRole.ts
@@ -189,7 +189,7 @@ function getImplicitRole(element: Element): string | null {
 			return "combobox";
 		case "th": {
 			const scope = element.getAttribute("scope");
-			if (scope && scope === "rowgroup") {
+			if (scope && ["row", "rowgroup"].indexOf(scope) !== -1) {
 				return "rowheader";
 			}
 			return "columnheader";

--- a/sources/getRole.ts
+++ b/sources/getRole.ts
@@ -46,7 +46,6 @@ const localNameToRoleMappings: Record<string, string | undefined> = {
 	tfoot: "rowgroup",
 	// WARNING: Only in certain context
 	td: "cell",
-	th: "columnheader",
 	thead: "rowgroup",
 	tr: "row",
 	ul: "list",
@@ -188,6 +187,13 @@ function getImplicitRole(element: Element): string | null {
 				return "listbox";
 			}
 			return "combobox";
+		case "th": {
+			const scope = element.getAttribute("scope");
+			if (scope && scope === "rowgroup") {
+				return "rowheader";
+			}
+			return "columnheader";
+		}
 	}
 	return null;
 }

--- a/sources/getRole.ts
+++ b/sources/getRole.ts
@@ -189,7 +189,7 @@ function getImplicitRole(element: Element): string | null {
 			return "combobox";
 		case "th": {
 			const scope = element.getAttribute("scope");
-			if (scope && ["row", "rowgroup"].indexOf(scope) !== -1) {
+			if (scope === "row" || scope === "rowgroup") {
 				return "rowheader";
 			}
 			return "columnheader";


### PR DESCRIPTION
Originally reported in https://github.com/testing-library/dom-testing-library/issues/930

In addition to this report, I fixed about `th scope=row`.
I fixed this just trusted the treating of Chrome and Firefox (ref: above report).

I added any test cases that may be needed. Anything else fix to testing?
Thanks,