### PR TITLE
fix: `input[type="number"]` maps to `[role="spinbutton"]`

### DIFF
--- a/.changeset/small-chairs-fly.md
+++ b/.changeset/small-chairs-fly.md
@@ -1,0 +1,5 @@
+---
+"dom-accessibility-api": patch
+---
+
+`<input type="number" />` now maps to `role` `spinbutton` (was `textbox` before).

--- a/sources/__tests__/getRole.js
+++ b/sources/__tests__/getRole.js
@@ -101,6 +101,7 @@ const cases = [
 	["input type=hidden", null, createElementFactory("input", {type: "hidden"})],
 	["input type=image", "button", createElementFactory("input", {type: "image"})],
 	["input type=month", null, createElementFactory("input", {type: "month"})],
+	["input type=number", "spinbutton", createElementFactory("input", {type: "number"})],
 	["input type=radio", "radio", createElementFactory("input", {type: "radio"})],
 	["input type=range", "slider", createElementFactory("input", {type: "range"})],
 	["input type=reset", "button", createElementFactory("input", {type: "reset"})],

--- a/sources/getRole.ts
+++ b/sources/getRole.ts
@@ -176,8 +176,8 @@ function getImplicitRole(element: Element): string | null {
 						return "combobox";
 					}
 					return "searchbox";
-        case "number":
-          return "spinbutton";
+				case "number":
+					return "spinbutton";
 				default:
 					return null;
 			}

--- a/sources/getRole.ts
+++ b/sources/getRole.ts
@@ -176,6 +176,8 @@ function getImplicitRole(element: Element): string | null {
 						return "combobox";
 					}
 					return "searchbox";
+        case "number":
+          return "spinbutton";
 				default:
 					return null;
 			}


### PR DESCRIPTION
https://www.w3.org/TR/html-aria/#el-input-number

This one was missing from the implementation/tests, so I went ahead and added it.