### PR TITLE
fix: Remove circular dependency

### DIFF
--- a/.changeset/modern-carpets-ring.md
+++ b/.changeset/modern-carpets-ring.md
@@ -1,0 +1,5 @@
+---
+"dom-accessibility-api": patch
+---
+
+Remover circular dependency, which fixes warnings thrown in certain environments.

--- a/sources/getRole.ts
+++ b/sources/getRole.ts
@@ -1,6 +1,17 @@
 // https://w3c.github.io/html-aria/#document-conformance-requirements-for-use-of-aria-attributes-in-html
 
-import { getLocalName } from "./util";
+/**
+ * Safe Element.localName for all supported environments
+ * @param element
+ */
+export function getLocalName(element: Element): string {
+	return (
+		// eslint-disable-next-line no-restricted-properties -- actual guard for environments without localName
+		element.localName ??
+		// eslint-disable-next-line no-restricted-properties -- required for the fallback
+		element.tagName.toLowerCase()
+	);
+}
 
 const localNameToRoleMappings: Record<string, string | undefined> = {
 	article: "article",

--- a/sources/util.ts
+++ b/sources/util.ts
@@ -1,17 +1,5 @@
-import getRole from "./getRole";
-
-/**
- * Safe Element.localName for all supported environments
- * @param element
- */
-export function getLocalName(element: Element): string {
-	return (
-		// eslint-disable-next-line no-restricted-properties -- actual guard for environments without localName
-		element.localName ??
-		// eslint-disable-next-line no-restricted-properties -- required for the fallback
-		element.tagName.toLowerCase()
-	);
-}
+export { getLocalName } from "./getRole";
+import getRole, { getLocalName } from "./getRole";
 
 export function isElement(node: Node | null): node is Element {
 	return node !== null && node.nodeType === node.ELEMENT_NODE;


### PR DESCRIPTION
Fixes #733 

`./getRole.ts` and `./util.ts` were importing each other, causing a circular dependency. This causes a warning when using this package (or packages that depend on this like `@testing-library/jest-dom`) at least when using Rollup.

To remove the warning I moved `getLocalName` to `getRole` and re-exported it from `util` so it is still available when importing from `./util`).