### PR TITLE
fix: Follow aria-labelledby and aria-describedby if they point to elements in the same shadow root

### DIFF
--- a/.changeset/violet-cooks-promise.md
+++ b/.changeset/violet-cooks-promise.md
@@ -1,0 +1,5 @@
+---
+"dom-accessibility-api": patch
+---
+
+Follow aria-labelledby and aria-describedby if they point to elements in the same shadow root.

--- a/sources/__tests__/accessible-description.js
+++ b/sources/__tests__/accessible-description.js
@@ -66,14 +66,14 @@ describe("wpt copies", () => {
 
 describe("content in shadow DOM", () => {
 	it("works for aria-labelledby on co-located elements in same shadow root", () => {
-		const container = renderIntoDocument('<div></div>')
-		const div = container.querySelector('div')
-		div.attachShadow({ mode: 'open' }).innerHTML = `
+		const container = renderIntoDocument("<div></div>");
+		const div = container.querySelector("div");
+		div.attachShadow({ mode: "open" }).innerHTML = `
 			<div id="theDescription">This is a button</div>
 			<button aria-describedby="theDescription">Click me</button>
-		`
+		`;
 
-		const button = div.shadowRoot.querySelector('button')
-		expect(computeAccessibleDescription(button)).toEqual('This is a button')
-	})
-})
+		const button = div.shadowRoot.querySelector("button");
+		expect(computeAccessibleDescription(button)).toEqual("This is a button");
+	});
+});

--- a/sources/__tests__/accessible-description.js
+++ b/sources/__tests__/accessible-description.js
@@ -65,7 +65,7 @@ describe("wpt copies", () => {
 });
 
 describe("content in shadow DOM", () => {
-	it("works for aria-labelledby on co-located elements in same shadow root", () => {
+	it("works for aria-labelledby on elements in same shadow root", () => {
 		const container = renderIntoDocument("<div></div>");
 		const div = container.querySelector("div");
 		div.attachShadow({ mode: "open" }).innerHTML = `

--- a/sources/__tests__/accessible-description.js
+++ b/sources/__tests__/accessible-description.js
@@ -63,3 +63,17 @@ describe("wpt copies", () => {
 		testMarkup(markup, expectedAccessibleName)
 	);
 });
+
+describe("content in shadow DOM", () => {
+	it("works for aria-labelledby on co-located elements in same shadow root", () => {
+		const container = renderIntoDocument('<div></div>')
+		const div = container.querySelector('div')
+		div.attachShadow({ mode: 'open' }).innerHTML = `
+			<div id="theDescription">This is a button</div>
+			<button aria-describedby="theDescription">Click me</button>
+		`
+
+		const button = div.shadowRoot.querySelector('button')
+		expect(computeAccessibleDescription(button)).toEqual('This is a button')
+	})
+})

--- a/sources/__tests__/accessible-name.js
+++ b/sources/__tests__/accessible-name.js
@@ -592,14 +592,14 @@ describe("options.hidden", () => {
 
 describe("content in shadow DOM", () => {
 	it("works for aria-labelledby on co-located elements in same shadow root", () => {
-		const container = renderIntoDocument('<div></div>')
-		const div = container.querySelector('div')
-		div.attachShadow({ mode: 'open' }).innerHTML = `
+		const container = renderIntoDocument("<div></div>");
+		const div = container.querySelector("div");
+		div.attachShadow({ mode: "open" }).innerHTML = `
 			<label id="theLabel">Type here</label>
 			<input type="text" aria-labelledby="theLabel">
-		`
+		`;
 
-		const input = div.shadowRoot.querySelector('input')
-		expect(computeAccessibleName(input)).toEqual('Type here')
-	})
-})
+		const input = div.shadowRoot.querySelector("input");
+		expect(computeAccessibleName(input)).toEqual("Type here");
+	});
+});

--- a/sources/__tests__/accessible-name.js
+++ b/sources/__tests__/accessible-name.js
@@ -589,3 +589,17 @@ describe("options.hidden", () => {
 		);
 	});
 });
+
+describe("content in shadow DOM", () => {
+	it("works for aria-labelledby on co-located elements in same shadow root", () => {
+		const container = renderIntoDocument('<div></div>')
+		const div = container.querySelector('div')
+		div.attachShadow({ mode: 'open' }).innerHTML = `
+			<label id="theLabel">Type here</label>
+			<input type="text" aria-labelledby="theLabel">
+		`
+
+		const input = div.shadowRoot.querySelector('input')
+		expect(computeAccessibleName(input)).toEqual('Type here')
+	})
+})

--- a/sources/__tests__/accessible-name.js
+++ b/sources/__tests__/accessible-name.js
@@ -591,7 +591,7 @@ describe("options.hidden", () => {
 });
 
 describe("content in shadow DOM", () => {
-	it("works for aria-labelledby on co-located elements in same shadow root", () => {
+	it("works for aria-labelledby on elements in same shadow root", () => {
 		const container = renderIntoDocument("<div></div>");
 		const div = container.querySelector("div");
 		div.attachShadow({ mode: "open" }).innerHTML = `

--- a/sources/util.ts
+++ b/sources/util.ts
@@ -90,8 +90,11 @@ export function queryIdRefs(node: Node, attributeName: string): Element[] {
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- safe due to hasAttribute check
 		const ids = node.getAttribute(attributeName)!.split(" ");
 
+		// Browsers that don't support shadow DOM won't have getRootNode
+		const root = node.getRootNode ? node.getRootNode() as (Document | ShadowRoot) : node.ownerDocument;
+
 		return ids
-			.map((id) => node.ownerDocument.getElementById(id))
+			.map((id) => root.getElementById(id))
 			.filter(
 				(element: Element | null): element is Element => element !== null
 				// TODO: why does this not narrow?

--- a/sources/util.ts
+++ b/sources/util.ts
@@ -91,7 +91,9 @@ export function queryIdRefs(node: Node, attributeName: string): Element[] {
 		const ids = node.getAttribute(attributeName)!.split(" ");
 
 		// Browsers that don't support shadow DOM won't have getRootNode
-		const root = node.getRootNode ? node.getRootNode() as (Document | ShadowRoot) : node.ownerDocument;
+		const root = node.getRootNode
+			? (node.getRootNode() as Document | ShadowRoot)
+			: node.ownerDocument;
 
 		return ids
 			.map((id) => root.getElementById(id))


### PR DESCRIPTION
Partially addresses #768. Fixes `aria-labelledby` and `aria-describedby` in the following situation:

1. The two elements in question (i.e. the element with `aria-*edby` and the element referenced by that attribute) are both located in the same shadow root.
2. The text contents of the second element are fully contained within its own DOM (not its shadow DOM).

I've added two tests to confirm the behavior as well.