### PR TITLE
chore: Pin release workflow actions to Major

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,23 +11,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v3
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
 
       # synced with #node-version
-      - name: Setup Node.js 14.x
-        uses: actions/setup-node@master
+      - name: Setup Node.js 16.x
+        uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
 
       - name: Install Dependencies
         run: yarn
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@master
+        uses: changesets/action@v1
         with:
           publish: yarn release
         env:


### PR DESCRIPTION
<details>
<summary>(Hopefully) fixed warnings</summary>

[Prepare or publish release](https://github.com/eps1lon/dom-accessibility-api/actions/runs/3816291228/jobs/6491830203)
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: changesets/action@master
[Prepare or publish release](https://github.com/eps1lon/dom-accessibility-api/actions/runs/3816291228/jobs/6491830203#step:5:8)
The workflow file using `changesets/action` is currently using `@master` as the version. This branch has been frozen and deprecated. Please update your workflow to either use `@v1` or a specific commit SHA that is tagged.
[Prepare or publish release](https://github.com/eps1lon/dom-accessibility-api/actions/runs/3816291228/jobs/6491830203#step:5:14)
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
[Prepare or publish release](https://github.com/eps1lon/dom-accessibility-api/actions/runs/3816291228/jobs/6491830203#step:5:16)
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
[Prepare or publish release](https://github.com/eps1lon/dom-accessibility-api/actions/runs/3816291228/jobs/6491830203#step:5:18)
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

-- https://github.com/eps1lon/dom-accessibility-api/actions/runs/3816291228
</details>