### PR TITLE
WIP: fix: omit blanket trimming of accumulatedText

### DIFF
--- a/sources/accessible-name-and-description.ts
+++ b/sources/accessible-name-and-description.ts
@@ -388,10 +388,12 @@ export function computeTextAlternative(
 		if (isElement(node) && computedStyleSupportsPseudoElements) {
 			const pseudoAfter = getComputedStyle(node, "::after");
 			const afterContent = getTextualContent(pseudoAfter);
-			accumulatedText = `${accumulatedText} ${afterContent}`;
+			if (afterContent) {
+				accumulatedText = `${accumulatedText} ${afterContent}`;
+			}
 		}
 
-		return accumulatedText.trim();
+		return accumulatedText;
 	}
 
 	/**


### PR DESCRIPTION
This is just a work in progress to get some feedback, it would probably be good to add tests for this case.

I've had this issue for a while, and I spend the day investigating a gmail 'recipient grid row'

<img width="182" alt="Screenshot 2023-07-17 at 7 19 22 PM" src="https://github.com/eps1lon/dom-accessibility-api/assets/3423750/5ee9c915-7a34-4641-9759-57cac1c3226e">

In gmail, the recipients involved includes a node which has a comma and a space after it.

When computing the label using this package, I was getting `Sydney,me 2` rather than `Sydney, me 2`

This issue of missing spaces has surfaced across many, many websites, and is ultimately the reason why I don't trust the package in most cases (it's an incredible fallback though).

---

I believe this line is the root cause, and I'm thinking the `trim()` only exists for the `afterContent` append.

I linked this package into ours and this fix instantly resolved the issue, so I'm probably biased, but it would be great if @eps1lon looked into this; the gmail is an easy repro