### PR TITLE
Add explicit typings location to support use in TypeScript ESM modules

### DIFF
--- a/.changeset/tame-ravens-whisper.md
+++ b/.changeset/tame-ravens-whisper.md
@@ -1,0 +1,5 @@
+---
+"dom-accessibility-api": patch
+---
+
+Add explicit typings location to support use in TypeScript ESM modules

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
 	"type": "commonjs",
 	"exports": {
 		"import": "./dist/index.mjs",
-		"require": "./dist/index.js"
+		"require": "./dist/index.js",
+		"types": "./dist/index.d.ts"
 	},
 	"license": "MIT",
 	"repository": {


### PR DESCRIPTION
The question and answer [here](https://stackoverflow.com/questions/72457791/typescript-packages-that-ship-with-mjs-and-d-ts-but-without-d-mts-how-to-i) describes the situation in detail and is exactly identical to the current situation in the `dom-accessibility-api` package.

**In short, TypeScript modules which are marked as `type: "module"` with `moduleResolution: "node16"` cannot consume this package because while an explicit entrypoint is specified for esm (`./dist/index.mjs`), there is no corresponding typings file.** In this case, TypeScript will look for such a typings file at the location `./dist/index.d.mts` by default, and this file does not exist.

The simplest fix for this, which is the entirety of my PR, is to provide a hint to TypeScript that types should _always_ be resolved at `./dist/index.d.ts` regardless of whether the importer is esm or cjs. This is a one-line change which will fix the problem; I have tested this in both commonjs and esm consumers by modifying the `package.json` in the installed version of `dom-accessibility-api`. 

Another, slightly more invasive approach would be to restructure your `package.json` to follow the structure they recommend in ["TypeScript v4.7 Release Notes"](https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#package-json-exports-imports-and-self-referencing):

```
// package.json
{
    "name": "my-package",
    "type": "module",
    "exports": {
        ".": {
            // Entry-point for `import "my-package"` in ESM
            "import": {
                // Where TypeScript will look.
                "types": "./types/esm/index.d.ts",

                // Where Node.js will look.
                "default": "./esm/index.js"
            },
            // Entry-point for `require("my-package") in CJS
            "require": {
                // Where TypeScript will look.
                "types": "./types/commonjs/index.d.cts",

                // Where Node.js will look.
                "default": "./commonjs/index.cjs"
            },
        }
    },

    // Fall-back for older versions of TypeScript
    "types": "./types/index.d.ts",

    // CJS fall-back for older versions of Node.js
    "main": "./commonjs/index.cjs"
}
```

**However I think my minimal change is sufficient and works for both commonjs and esm consumers (tested in TypeScript 5.1.3 but should work for any version which supports `exports`) and will not affect older consumers which do not recognize `exports`.**

Since your package does not have alternate typings for any export, this is correct in any case and cannot break anyone downstream (as far as I can tell, there are no special cases where certain customers should receive different types who will be broken now).