### PR TITLE
Ensure types are declared first in `exports` field

### DIFF
--- a/.changeset/four-humans-repair.md
+++ b/.changeset/four-humans-repair.md
@@ -1,0 +1,5 @@
+---
+"dom-accessibility-api": patch
+---
+
+Ensure types are declared first in `exports` field

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
 	"module": "dist/index.mjs",
 	"type": "commonjs",
 	"exports": {
+		"types": "./dist/index.d.ts",
 		"import": "./dist/index.mjs",
-		"require": "./dist/index.js",
-		"types": "./dist/index.d.ts"
+		"require": "./dist/index.js"
 	},
 	"license": "MIT",
 	"repository": {


### PR DESCRIPTION
Flagged by https://publint.dev/dom-accessibility-api@0.6.2
/cc @hiebj 