### PR TITLE
fix: The <form> element now always exposes the role "form"

### DIFF
--- a/sources/getRole.ts
+++ b/sources/getRole.ts
@@ -26,7 +26,6 @@ const localNameToRoleMappings: Record<string, string | undefined> = {
 	dt: "term",
 	fieldset: "group",
 	figure: "figure",
-	// WARNING: Only with an accessible name
 	form: "form",
 	footer: "contentinfo",
 	h1: "heading",


### PR DESCRIPTION
This has been changed in the ARIA spec in
https://github.com/w3c/html-aria/pull/402.

See also testing-library/dom-testing-library#1293