### PR TITLE
fix: Use placeholder attribute as accessible name

### DIFF
--- a/sources/__tests__/accessible-name.js
+++ b/sources/__tests__/accessible-name.js
@@ -404,6 +404,11 @@ test.each([
 		`<button title="You should really click this" data-test>click me</button>`,
 		"click me",
 	],
+	// https://www.w3.org/TR/html-aam-1.0/#input-type-text-input-type-password-input-type-number-input-type-search-input-type-tel-input-type-email-input-type-url-and-textarea-element-accessible-name-computation
+	[`<input type="text" data-test title="address" placeholder="Type here" />`, "address"],
+	[`<input type="text" data-test placeholder="Type here" />`, "Type here"],
+	[`<textarea data-test title="address" placeholder="Type here" />`, "address"],
+	[`<textarea data-test placeholder="Type here" />`, "Type here"],
 	// https://w3c.github.io/html-aam/#input-type-button-input-type-submit-and-input-type-reset-accessible-name-computation
 	[`<input data-test value="Submit form" type="submit" />`, "Submit form"],
 	// https://w3c.github.io/html-aam/#input-type-image

--- a/sources/accessible-name-and-description.ts
+++ b/sources/accessible-name-and-description.ts
@@ -483,12 +483,35 @@ export function computeTextAlternative(
 		}
 
 		if (
+			(isHTMLInputElement(node) &&
+			(
+				node.type === "text" ||
+				node.type === "password" ||
+				node.type === "number" ||
+				node.type === "search" ||
+				node.type === "tel" ||
+				node.type === "email" ||
+				node.type === "url"
+			)) || isHTMLTextAreaElement(node)
+		) {
+			// https://www.w3.org/TR/html-aam-1.0/#input-type-text-input-type-password-input-type-number-input-type-search-input-type-tel-input-type-email-input-type-url-and-textarea-element-accessible-name-computation
+			const nameFromTitle = useAttribute(node, "title");
+			if (nameFromTitle !== null) {
+				return nameFromTitle;
+			}
+			const nameFromPlaceholder = useAttribute(node, "placeholder");
+			if (nameFromPlaceholder !== null) {
+				return nameFromPlaceholder;
+			}
+		}
+
+		if (
 			isHTMLInputElement(node) &&
 			(node.type === "button" ||
 				node.type === "submit" ||
 				node.type === "reset")
 		) {
-			// https://w3c.github.io/html-aam/#input-type-text-input-type-password-input-type-search-input-type-tel-input-type-email-input-type-url-and-textarea-element-accessible-description-computation
+			// https://www.w3.org/TR/html-aam-1.0/#input-type-button-input-type-submit-and-input-type-reset-accessible-name-computation
 			const nameFromValue = useAttribute(node, "value");
 			if (nameFromValue !== null) {
 				return nameFromValue;


### PR DESCRIPTION
According to [HTML-AAM](https://www.w3.org/TR/html-aam-1.0/#input-type-text-input-type-password-input-type-number-input-type-search-input-type-tel-input-type-email-input-type-url-and-textarea-element-accessible-name-computation), `placeholder` attribute will be used as accessible name if text-field elements (`input` element with some types or `textarea` element) do not have `aria-label`, `aria-labelledby` attributes, related `label` element, or `title` attribute.

So, I changed `computeTextAlternative()` function to use `placeholder` attribute. And to take priority for `title` attribute, changed to use `title` attribute before it.