### PR TITLE
Fix inline element spacing issue

### DIFF
--- a/sources/__tests__/accessible-name.js
+++ b/sources/__tests__/accessible-name.js
@@ -181,7 +181,7 @@ describe("to upstream", () => {
 	foo
 	<input type="text" value="David" />
 </label>
-<input data-test id="test" type="text" value="baz">			
+<input data-test id="test" type="text" value="baz">
 `,
 			"foo David",
 		],
@@ -192,7 +192,7 @@ describe("to upstream", () => {
 	foo
 	<textarea>David</textarea>
 </label>
-<input data-test id="test" type="text" value="baz">			
+<input data-test id="test" type="text" value="baz">
 `,
 			"foo David",
 		],
@@ -338,7 +338,7 @@ test.each([
 	label:after { content:" fruit"; }
 </style>
 <label for="test">fancy</label>
-<input type="image" src="foo.jpg" id="test" data-test />	
+<input type="image" src="foo.jpg" id="test" data-test />
 `,
 		"fancy",
 	],
@@ -448,6 +448,8 @@ test.each([
 		`,
 		"Full Refund Refund Type",
 	],
+	["<button data-test>abc<span> - </span>123</button>", "abc - 123"],
+	["<div data-test role=\"button\">abc<span>-</span>123</div>", "abc-123"]
 ])(`misc #%#`, (markup, expectedAccessibleName) => {
 	expect(markup).toRenderIntoDocumentAccessibleName(expectedAccessibleName);
 });
@@ -499,7 +501,7 @@ describe("prohibited naming", () => {
 		],
 		[
 			"deletion",
-			"<button data-test>aria <span role='deletion'>1.1</span><span>1.2</span></button>",
+			"<button data-test>aria <span role='deletion'>1.1</span> <span>1.2</span></button>",
 			"aria 1.1 1.2",
 		],
 		[
@@ -514,7 +516,7 @@ describe("prohibited naming", () => {
 		],
 		[
 			"insertion",
-			"<button data-test><span role='insertion'>wai</span>aria</button>",
+			"<button data-test><span role='insertion'>wai</span> aria</button>",
 			"wai aria",
 		],
 		[
@@ -540,12 +542,12 @@ describe("prohibited naming", () => {
 		[
 			"subscript",
 			"<button data-test>A<span role='subscript'>_x</span></button>",
-			"A _x",
+			"A_x",
 		],
 		[
 			"superscript",
 			"<button data-test>2<span role='superscript'>64</span></button>",
-			"2 64",
+			"264",
 		],
 	])(
 		"role '%s'can be part of the accessible name of another element",

--- a/sources/__tests__/accessible-name.js
+++ b/sources/__tests__/accessible-name.js
@@ -449,7 +449,7 @@ test.each([
 		"Full Refund Refund Type",
 	],
 	["<button data-test>abc<span> - </span>123</button>", "abc - 123"],
-	["<div data-test role=\"button\">abc<span>-</span>123</div>", "abc-123"]
+	['<div data-test role="button">abc<span>-</span>123</div>', "abc-123"],
 ])(`misc #%#`, (markup, expectedAccessibleName) => {
 	expect(markup).toRenderIntoDocumentAccessibleName(expectedAccessibleName);
 });

--- a/sources/accessible-name-and-description.ts
+++ b/sources/accessible-name-and-description.ts
@@ -386,12 +386,50 @@ export function computeTextAlternative(
 
 	function isElementInlineLevel(child: Node): boolean {
 		let inline = false;
-		const defaultInlineElementTags = ["a", "abbr", "acronym", "b", "bdo", "big", "br", "button", "cite", "code", "dfn", "em", "i", "img", "input", "kbd", "label", "map", "object", "output", "q", "samp", "script", "select", "small", "span", "strong", "sub", "sup", "textarea", "time", "tt", "var", '#text'];
+		const defaultInlineElementTags = [
+			"a",
+			"abbr",
+			"acronym",
+			"b",
+			"bdo",
+			"big",
+			"br",
+			"button",
+			"cite",
+			"code",
+			"dfn",
+			"em",
+			"i",
+			"img",
+			"input",
+			"kbd",
+			"label",
+			"map",
+			"object",
+			"output",
+			"q",
+			"samp",
+			"script",
+			"select",
+			"small",
+			"span",
+			"strong",
+			"sub",
+			"sup",
+			"textarea",
+			"time",
+			"tt",
+			"var",
+			"#text",
+		];
 		if (isElement(child)) {
-			inline = getComputedStyle(child).getPropertyValue("display").indexOf('inline') > -1;
+			inline =
+				getComputedStyle(child).getPropertyValue("display").indexOf("inline") >
+				-1;
 		}
 		if (!inline) {
-			inline = defaultInlineElementTags.indexOf(child.nodeName.toLowerCase()) > -1;
+			inline =
+				defaultInlineElementTags.indexOf(child.nodeName.toLowerCase()) > -1;
 		}
 		return inline;
 	}

--- a/sources/accessible-name-and-description.ts
+++ b/sources/accessible-name-and-description.ts
@@ -422,12 +422,6 @@ export function computeTextAlternative(
 			// TODO: Unclear why display affects delimiter
 			// see https://github.com/w3c/accname/issues/3
 			const separator = !isElementInlineLevel(child) ? " " : "";
-			// console.log(`'${result}'`)
-			// console.log('getComputedStyle(child).getPropertyValue("display"):', isElementInlineLevel(child), child.nodeName, isElement(child), isElement(child) ? getComputedStyle(child).getPropertyValue('display') :'nope');
-			// if (isElement(child)) {
-			// console.log(`'${getComputedStyle(document.createElement(child.nodeName.toLowerCase())).getPropertyValue('display')}'`)
-			// }
-			// trailing separator for wpt tests
 			accumulatedText += `${separator}${result}${separator}`;
 		});
 		if (isElement(node) && computedStyleSupportsPseudoElements) {
@@ -435,7 +429,7 @@ export function computeTextAlternative(
 			const afterContent = getTextualContent(pseudoAfter);
 			accumulatedText = `${accumulatedText} ${afterContent}`;
 		}
-//console.log('accumulatedText:', accumulatedText);
+
 		return accumulatedText;
 	}
 

--- a/sources/accessible-name-and-description.ts
+++ b/sources/accessible-name-and-description.ts
@@ -384,6 +384,18 @@ export function computeTextAlternative(
 		return style;
 	};
 
+	function isElementInlineLevel(child: Node): boolean {
+		let inline = false;
+		const defaultInlineElementTags = ["a", "abbr", "acronym", "b", "bdo", "big", "br", "button", "cite", "code", "dfn", "em", "i", "img", "input", "kbd", "label", "map", "object", "output", "q", "samp", "script", "select", "small", "span", "strong", "sub", "sup", "textarea", "time", "tt", "var", '#text'];
+		if (isElement(child)) {
+			inline = getComputedStyle(child).getPropertyValue("display").indexOf('inline') > -1;
+		}
+		if (!inline) {
+			inline = defaultInlineElementTags.indexOf(child.nodeName.toLowerCase()) > -1;
+		}
+		return inline;
+	}
+
 	// 2F.i
 	function computeMiscTextAlternative(
 		node: Node,
@@ -409,10 +421,12 @@ export function computeTextAlternative(
 			});
 			// TODO: Unclear why display affects delimiter
 			// see https://github.com/w3c/accname/issues/3
-			const display = isElement(child)
-				? getComputedStyle(child).getPropertyValue("display")
-				: "inline";
-			const separator = display !== "inline" ? " " : "";
+			const separator = !isElementInlineLevel(child) ? " " : "";
+			// console.log(`'${result}'`)
+			// console.log('getComputedStyle(child).getPropertyValue("display"):', isElementInlineLevel(child), child.nodeName, isElement(child), isElement(child) ? getComputedStyle(child).getPropertyValue('display') :'nope');
+			// if (isElement(child)) {
+			// console.log(`'${getComputedStyle(document.createElement(child.nodeName.toLowerCase())).getPropertyValue('display')}'`)
+			// }
 			// trailing separator for wpt tests
 			accumulatedText += `${separator}${result}${separator}`;
 		});
@@ -421,8 +435,8 @@ export function computeTextAlternative(
 			const afterContent = getTextualContent(pseudoAfter);
 			accumulatedText = `${accumulatedText} ${afterContent}`;
 		}
-
-		return accumulatedText.trim();
+//console.log('accumulatedText:', accumulatedText);
+		return accumulatedText;
 	}
 
 	/**


### PR DESCRIPTION
There were some issues with trying to use `getComputedStyle` with JSDom. It doesn't tend to return "default" styles, it will just return an empty string. (see [here](https://github.com/jsdom/jsdom/issues/2688) & [here](https://github.com/jsdom/jsdom/issues/3339)) 

This means that it was adding spaces around inline level elements such as `span` when it should not have been. This PR attempts to remedy that by falling back to a hardcoded list of inline level element tags if the computed styles returns an empty string.