### PR TITLE
fix: use referenced names in descriptions

### DIFF
--- a/.changeset/describedby-referenced-names.md
+++ b/.changeset/describedby-referenced-names.md
@@ -1,0 +1,5 @@
+---
+"dom-accessibility-api": patch
+---
+
+Use accessible names for content referenced by `aria-describedby`.

--- a/sources/__tests__/accessible-description.js
+++ b/sources/__tests__/accessible-description.js
@@ -91,3 +91,17 @@ describe("content in shadow DOM", () => {
 		expect(computeAccessibleDescription(button)).toEqual("This is a button");
 	});
 });
+
+describe("aria-describedby", () => {
+	it("uses accessible names from referenced content", () => {
+		expect(
+			`
+			<input data-test aria-describedby="error-message" />
+			<div id="error-message">
+				<span aria-label="Error icon">error</span>
+				<span>The error message</span>
+			</div>
+			`,
+		).toRenderIntoDocumentAccessibleDescription("Error icon The error message");
+	});
+});

--- a/sources/accessible-name-and-description.ts
+++ b/sources/accessible-name-and-description.ts
@@ -404,7 +404,7 @@ export function computeTextAlternative(
 		childNodes.forEach((child) => {
 			const result = computeTextAlternative(child, {
 				isEmbeddedInLabel: context.isEmbeddedInLabel,
-				isReferenced: false,
+				isReferenced: context.isReferenced,
 				recursion: true,
 			});
 			// TODO: Unclear why display affects delimiter
@@ -647,7 +647,7 @@ export function computeTextAlternative(
 				(isElement(current) && current.getAttribute("aria-label")) ||
 				""
 			).trim();
-			if (ariaLabel !== "" && compute === "name") {
+			if (ariaLabel !== "" && (compute === "name" || context.isReferenced)) {
 				consultedNodes.add(current);
 				return ariaLabel;
 			}
@@ -716,7 +716,7 @@ export function computeTextAlternative(
 		) {
 			const accumulatedText2F = computeMiscTextAlternative(current, {
 				isEmbeddedInLabel: context.isEmbeddedInLabel,
-				isReferenced: false,
+				isReferenced: context.isReferenced,
 			});
 			if (accumulatedText2F !== "") {
 				consultedNodes.add(current);
@@ -733,7 +733,7 @@ export function computeTextAlternative(
 			consultedNodes.add(current);
 			return computeMiscTextAlternative(current, {
 				isEmbeddedInLabel: context.isEmbeddedInLabel,
-				isReferenced: false,
+				isReferenced: context.isReferenced,
 			});
 		}
 

--- a/tests/cypress/integration/web-platform-test.cy.js
+++ b/tests/cypress/integration/web-platform-test.cy.js
@@ -5,7 +5,7 @@ const usedApiIndex = 0; // ATK
 context("wpt", () => {
 	[
 		["description_1.0_combobox-focusable-manual.html", "fail"],
-		["description_from_content_of_describedby_element-manual.html", "fail"],
+		["description_from_content_of_describedby_element-manual.html", "pass"],
 		["description_link-with-label-manual.html", "pass"],
 		["description_test_case_557-manual.html", "pass"],
 		["description_test_case_664-manual.html", "pass"],

--- a/tests/wpt-jsdom/to-run.yaml
+++ b/tests/wpt-jsdom/to-run.yaml
@@ -2,8 +2,7 @@ DIR: accname
 
 description_1.0_combobox-focusable-manual.html:
   [fail, title already used for name]
-description_from_content_of_describedby_element-manual.html:
-  [fail, test considers aria-label for description which is wrong IMO]
+description_from_content_of_describedby_element-manual.html: [pass]
 name_file-label-inline-block-elements-manual.html:
   [fail, whitespace issue, likely due to `display`]
 name_file-label-inline-block-styles-manual.html: [fail, missing word, unknown]


### PR DESCRIPTION
Fixes #1064.

This keeps the aria-describedby referenced subtree in referenced context while computing text alternatives, so descendants with aria-label contribute their accessible name to the computed description instead of falling back to raw text content.

It also updates the existing WPT expectations for description_from_content_of_describedby_element-manual.html from fail to pass.

Verification:

- yarn test sources/__tests__/accessible-description.js --runTestsByPath --runInBand
- yarn test
- yarn prettier --check sources/accessible-name-and-description.ts sources/__tests__/accessible-description.js tests/wpt-jsdom/to-run.yaml tests/cypress/integration/web-platform-test.cy.js .changeset/describedby-referenced-names.md
- yarn lint
- yarn test:types
- yarn build

Note: yarn test:wpt:jsdom could not complete locally because initializing the tests/wpt submodule stalled while cloning the upstream WPT repository.
